### PR TITLE
✨ Feature: #57 Empty Note View

### DIFF
--- a/learningTool/Views/HomeView/HomeView.swift
+++ b/learningTool/Views/HomeView/HomeView.swift
@@ -136,6 +136,44 @@ struct HomeView: View {
                     }
                     .padding()
                 }
+                .overlay {
+                    // 노트가 없을 때 기본 텍스트 표시
+                    if shouldShowEmptyState {
+                        VStack(spacing: 4) {
+                            Text("아직은 노트가 없어요!")
+                                .font(.system(size: 16, weight: .regular))
+                                .foregroundStyle(Color.text3)
+                            
+                            Text("하단 추가 버튼을 눌러서 첫 학습을 시작해 보세요!")
+                                .font(.system(size: 16, weight: .regular))
+                                .foregroundStyle(Color.text3)
+                            
+                            Spacer()
+                                .frame(height: 12)
+                            
+                            Text("사용법을 알고 싶으신가요?")
+                                .font(.system(size: 16, weight: .regular))
+                                .foregroundStyle(Color.text3)
+                            
+                            HStack(spacing: 4) {
+                                Text("좌측 하단의")
+                                    .font(.system(size: 16, weight: .regular))
+                                    .foregroundStyle(Color.text3)
+                                
+                                Image(systemName: "questionmark.circle.fill")
+                                    .font(.system(size: 16))
+                                    .foregroundStyle(Color.text3)
+                                
+                                Text("도움말 버튼을 클릭해 보세요!")
+                                    .font(.system(size: 16, weight: .regular))
+                                    .foregroundStyle(Color.text3)
+                            }
+                        }
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .offset(y: -50)
+                    }
+                }
                 .overlay(alignment: .bottomTrailing) {
                     Button {
                         viewModel.addButtonTapped()
@@ -229,6 +267,15 @@ struct HomeView: View {
         viewModel.searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
     
+    // 빈 상태 표시 여부
+    private var shouldShowEmptyState: Bool {
+        if isAllView {
+            let items = searchQuery.isEmpty ? allItems : allItemsFiltered
+            return items.isEmpty
+        } else {
+            return filteredNotes.isEmpty
+        }
+    }
     
     private var filteredNotes: [Note] {
         // 1) 폴더 선택 필터


### PR DESCRIPTION
✨ Feature: #57 Empty Note View

## ✨ What’s this PR?
생성된 노트가 없을 때, 보여주는 텍스트입니다.

### 📌 관련 이슈 (Related Issue)
- Closes #57 

---
### 🧶 주요 변경 내용 (Summary)
- HomeView 페이지에 작업
- 디폴트 텍스트 반영

---
### 📸 스크린샷 (Optional)
<img width="637" height="453" alt="스크린샷 2025-10-29 오후 4 38 31" src="https://github.com/user-attachments/assets/71927da1-0adc-480e-b100-c26cacd43d91" />


---
### 🧪 테스트 / 검증 내역
- [x] UI 정상 동작 확인

---
### 💬 기타 공유 사항
- 로직을 건드리지 않고, 작업하려 했으나 건드린 경우 후순위로 재작업
(바이브코딩으로는 결국 계속 건드릴 수 밖에 없기 때문에 로직 담당자가 해야 함)

- 홈뷰 상단 아이콘들 디자인 작업도 동일한 상황 > 작업 대기
- 노트 생성 시, 텍스트 사라지는 부분은 추가 개발 필요
