### PR TITLE
🎨 Design:  #70 세팅뷰 기능 연결 작업

### DIFF
--- a/learningTool/ViewModels/SidebarViewModel.swift
+++ b/learningTool/ViewModels/SidebarViewModel.swift
@@ -57,7 +57,7 @@ class SidebarViewModel: ObservableObject {
     }
     
     func settingsTapped() {
-        print("Settings tapped")
+        NotificationCenter.default.post(name: .showSettings, object: nil)
     }
     
     func trashTapped() {

--- a/learningTool/Views/HomeView/HomeView.swift
+++ b/learningTool/Views/HomeView/HomeView.swift
@@ -48,12 +48,14 @@ struct HomeView: View {
     }
 
     @State private var isHelpPresented: Bool = false
+    @State private var isShowingSettings: Bool = false
     @State private var isFolderDeletePresented: Bool = false
     @State private var folderIDsPendingDelete = Set<PersistentIdentifier>()
 
     var body: some View {
         NavigationSplitView {
             SidebarView(onFolderSelected: { name in
+                isShowingSettings = false
                 if name == "__ALL__" {
                     headerSubtitle = "전체 보기"
                     selectedFolderName = "__ALL__"
@@ -73,105 +75,106 @@ struct HomeView: View {
             .navigationSplitViewColumnWidth(min: 280, ideal: 320, max: 400)
             .toolbar(.hidden, for: .navigationBar)
         } detail: {
-            VStack(spacing: 0) {
-                // 헤더
-                HStack {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("{$app_name}")
-                            .font(.system(size: 28, weight: .semibold))
-                            .foregroundStyle(Color.text1)
-                        
-                        Text(headerSubtitle)
-                            .font(.system(size: 22, weight: .medium))
-                            .foregroundStyle(Color.text2)
-                    }
-                    
-                    Spacer()
-                    
-                    // 검색 + 뷰모드 버튼들
-                    HStack(spacing: 12) {
-                        HStack {
-                            Image(systemName: "magnifyingglass")
-                                .foregroundStyle(Color.text3)
-                            TextField("노트 검색", text: $viewModel.searchText, axis: .horizontal)
-                                .font(.system(size: 16))
-                                .lineLimit(1)
-                        }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 8)
-                        .frame(minWidth: 220, maxWidth: 320)
-                        .background(Color.background2)
-                        .cornerRadius(8)
-
-
-                        Button {
-                            showNoteSortMenu.toggle()
-                        } label: {
-                            Image(systemName: "line.3.horizontal")
-                                .font(.system(size: 16, weight: .semibold))
+            ZStack {
+                VStack(spacing: 0) {
+                    // 헤더
+                    HStack {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("{$app_name}")
+                                .font(.system(size: 28, weight: .semibold))
+                                .foregroundStyle(Color.text1)
+                            
+                            Text(headerSubtitle)
+                                .font(.system(size: 22, weight: .medium))
                                 .foregroundStyle(Color.text2)
-                                .frame(width: 36, height: 36)
-                                .background(Color.background2)
-                                .clipShape(Circle())
-                                .overlay(Circle().stroke(Color.borderColor, lineWidth: 1))
                         }
-                        .buttonStyle(.plain)
-                        .popover(isPresented: $showNoteSortMenu, arrowEdge: .top) {
-                            VStack(spacing: 0) {
-                                ForEach(NoteSortOption.allCases, id: \.self) { option in
-                                    Button {
-                                        noteSort = option
-                                        showNoteSortMenu = false
-                                    } label: {
-                                        HStack(spacing: 10) {
-                                            if noteSort == option {
-                                                Image(systemName: "checkmark")
-                                                    .font(.system(size: 12, weight: .bold))
-                                            } else {
-                                                Color.clear.frame(width: 12, height: 12)
+                        
+                        Spacer()
+                        
+                        // 검색 + 뷰모드 버튼들
+                        HStack(spacing: 12) {
+                            HStack {
+                                Image(systemName: "magnifyingglass")
+                                    .foregroundStyle(Color.text3)
+                                TextField("노트 검색", text: $viewModel.searchText, axis: .horizontal)
+                                    .font(.system(size: 16))
+                                    .lineLimit(1)
+                            }
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .frame(minWidth: 220, maxWidth: 320)
+                            .background(Color.background2)
+                            .cornerRadius(8)
+                            
+                            
+                            Button {
+                                showNoteSortMenu.toggle()
+                            } label: {
+                                Image(systemName: "line.3.horizontal")
+                                    .font(.system(size: 16, weight: .semibold))
+                                    .foregroundStyle(Color.text2)
+                                    .frame(width: 36, height: 36)
+                                    .background(Color.background2)
+                                    .clipShape(Circle())
+                                    .overlay(Circle().stroke(Color.borderColor, lineWidth: 1))
+                            }
+                            .buttonStyle(.plain)
+                            .popover(isPresented: $showNoteSortMenu, arrowEdge: .top) {
+                                VStack(spacing: 0) {
+                                    ForEach(NoteSortOption.allCases, id: \.self) { option in
+                                        Button {
+                                            noteSort = option
+                                            showNoteSortMenu = false
+                                        } label: {
+                                            HStack(spacing: 10) {
+                                                if noteSort == option {
+                                                    Image(systemName: "checkmark")
+                                                        .font(.system(size: 12, weight: .bold))
+                                                } else {
+                                                    Color.clear.frame(width: 12, height: 12)
+                                                }
+                                                Text(option.rawValue)
+                                                    .font(.system(size: 14))
+                                                Spacer()
                                             }
-                                            Text(option.rawValue)
-                                                .font(.system(size: 14))
-                                            Spacer()
+                                            .padding(.horizontal, 14)
+                                            .padding(.vertical, 10)
+                                            .contentShape(Rectangle())
                                         }
-                                        .padding(.horizontal, 14)
-                                        .padding(.vertical, 10)
-                                        .contentShape(Rectangle())
-                                    }
-                                    .buttonStyle(.plain)
-
-                                    if option != NoteSortOption.allCases.last {
-                                        Divider().background(Color.borderColor)
+                                        .buttonStyle(.plain)
+                                        
+                                        if option != NoteSortOption.allCases.last {
+                                            Divider().background(Color.borderColor)
+                                        }
                                     }
                                 }
+                                .frame(width: 180)
+                                .background(Color.background1)
+                                .cornerRadius(14)
+                                .overlay(RoundedRectangle(cornerRadius: 14).stroke(Color.borderColor, lineWidth: 1))
                             }
-                            .frame(width: 180)
-                            .background(Color.background1)
-                            .cornerRadius(14)
-                            .overlay(RoundedRectangle(cornerRadius: 14).stroke(Color.borderColor, lineWidth: 1))
-                        }
-                        
-                        
-                        // ▼ 토글 버튼 (오른쪽)
-                        ViewModeToggle(selection: $viewModel.selectedViewMode) { mode in
-                            viewModel.viewModeButtonTapped(mode)
-                        }
-                        .frame(width: 116, height: 36)
-                    }
-                }
-                .padding()
-                
-                
-                Divider().background(Color.borderColor)
-                
-                
-                // 노트 그리드
-                ScrollView {
-                    if viewModel.selectedViewMode == .list {// ✅ 리스트 모드 (테이블 형태)
-                        VStack(spacing: 0) {
-                            listHeaderRow() // 헤더
-                            Divider().background(Color.borderColor)
                             
+                            
+                            // ▼ 토글 버튼 (오른쪽)
+                            ViewModeToggle(selection: $viewModel.selectedViewMode) { mode in
+                                viewModel.viewModeButtonTapped(mode)
+                            }
+                            .frame(width: 116, height: 36)
+                        }
+                    }
+                    .padding()
+                    
+                    
+                    Divider().background(Color.borderColor)
+                    
+                    
+                    // 노트 그리드
+                    ScrollView {
+                        if viewModel.selectedViewMode == .list {// ✅ 리스트 모드 (테이블 형태)
+                            VStack(spacing: 0) {
+                                listHeaderRow() // 헤더
+                                Divider().background(Color.borderColor)
+                                
                                 LazyVStack(spacing: 8) {
                                     if isAllView {
                                         let items = searchQuery.isEmpty ? allItems : allItemsFiltered
@@ -190,87 +193,93 @@ struct HomeView: View {
                                 .padding(.top, 8)
                                 .padding(.bottom, 4)
                             }
-                        
-                    } else {
-                        // ✅ 기존 그리드 모드 (네 코드 그대로)
-                        LazyVGrid(columns: columns, spacing: 16) {
-                            if isAllView {
-                                let items = searchQuery.isEmpty ? allItems : allItemsFiltered
-                                ForEach(items.indices, id: \.self) { idx in
-                                    homeItemView(items[idx])     // 기존 타일 UI
-                                }
-                            } else {
-                                ForEach(filteredNotes) { note in
-                                    NoteComponent(note: note)
-                                        .onTapGesture { onNoteSelected?(note) }
-                                        .contextMenu {
-                                            Button("이름 변경") {
-                                                noteToRename = note
-                                                renameText = note.title
+                            
+                        } else {
+                            // ✅ 기존 그리드 모드 (네 코드 그대로)
+                            LazyVGrid(columns: columns, spacing: 16) {
+                                if isAllView {
+                                    let items = searchQuery.isEmpty ? allItems : allItemsFiltered
+                                    ForEach(items.indices, id: \.self) { idx in
+                                        homeItemView(items[idx])     // 기존 타일 UI
+                                    }
+                                } else {
+                                    ForEach(filteredNotes) { note in
+                                        NoteComponent(note: note)
+                                            .onTapGesture { onNoteSelected?(note) }
+                                            .contextMenu {
+                                                Button("이름 변경") {
+                                                    noteToRename = note
+                                                    renameText = note.title
+                                                }
+                                                Button("삭제", role: .destructive) {
+                                                    modelContext.delete(note)
+                                                    try? modelContext.save()
+                                                }
                                             }
-                                            Button("삭제", role: .destructive) {
-                                                modelContext.delete(note)
-                                                try? modelContext.save()
-                                            }
-                                        }
+                                    }
                                 }
                             }
+                            .padding()
                         }
-                        .padding()
                     }
-                }
-                .overlay {
-                    // 노트가 없을 때 기본 텍스트 표시
-                    if shouldShowEmptyState {
-                        VStack(spacing: 4) {
-                            Text("아직은 노트가 없어요!")
-                                .font(.system(size: 16, weight: .regular))
-                                .foregroundStyle(Color.text3)
-                            
-                            Text("하단 추가 버튼을 눌러서 첫 학습을 시작해 보세요!")
-                                .font(.system(size: 16, weight: .regular))
-                                .foregroundStyle(Color.text3)
-                            
-                            Spacer()
-                                .frame(height: 12)
-                            
-                            Text("사용법을 알고 싶으신가요?")
-                                .font(.system(size: 16, weight: .regular))
-                                .foregroundStyle(Color.text3)
-                            
-                            HStack(spacing: 4) {
-                                Text("좌측 하단의")
+                    .overlay {
+                        // 노트가 없을 때 기본 텍스트 표시
+                        if shouldShowEmptyState {
+                            VStack(spacing: 4) {
+                                Text("아직은 노트가 없어요!")
                                     .font(.system(size: 16, weight: .regular))
                                     .foregroundStyle(Color.text3)
                                 
-                                Image(systemName: "questionmark.circle.fill")
-                                    .font(.system(size: 16))
-                                    .foregroundStyle(Color.text3)
-                                
-                                Text("도움말 버튼을 클릭해 보세요!")
+                                Text("하단 추가 버튼을 눌러서 첫 학습을 시작해 보세요!")
                                     .font(.system(size: 16, weight: .regular))
                                     .foregroundStyle(Color.text3)
+                                
+                                Spacer()
+                                    .frame(height: 12)
+                                
+                                Text("사용법을 알고 싶으신가요?")
+                                    .font(.system(size: 16, weight: .regular))
+                                    .foregroundStyle(Color.text3)
+                                
+                                HStack(spacing: 4) {
+                                    Text("좌측 하단의")
+                                        .font(.system(size: 16, weight: .regular))
+                                        .foregroundStyle(Color.text3)
+                                    
+                                    Image(systemName: "questionmark.circle.fill")
+                                        .font(.system(size: 16))
+                                        .foregroundStyle(Color.text3)
+                                    
+                                    Text("도움말 버튼을 클릭해 보세요!")
+                                        .font(.system(size: 16, weight: .regular))
+                                        .foregroundStyle(Color.text3)
+                                }
                             }
+                            .multilineTextAlignment(.center)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .offset(y: -50)
                         }
-                        .multilineTextAlignment(.center)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .offset(y: -50)
+                    }
+                    .overlay(alignment: .bottomTrailing) {
+                        Button {
+                            viewModel.addButtonTapped()
+                            withAnimation(.easeInOut(duration: 0.2)) { showCreateNote = true }
+                        } label: {
+                            Image(systemName: "plus")
+                                .font(.system(size: 22))
+                                .foregroundStyle(.white)
+                                .frame(width: 60, height: 60)
+                                .background(Color.secondColor)
+                                .clipShape(Circle())
+                                .shadow(color: Color.secondColor.opacity(0.4), radius: 8, x: 0, y: 4)
+                        }
+                        .padding(32)
                     }
                 }
-                .overlay(alignment: .bottomTrailing) {
-                    Button {
-                        viewModel.addButtonTapped()
-                        withAnimation(.easeInOut(duration: 0.2)) { showCreateNote = true }
-                    } label: {
-                        Image(systemName: "plus")
-                            .font(.system(size: 22))
-                            .foregroundStyle(.white)
-                            .frame(width: 60, height: 60)
-                            .background(Color.secondColor)
-                            .clipShape(Circle())
-                            .shadow(color: Color.secondColor.opacity(0.4), radius: 8, x: 0, y: 4)
-                    }
-                    .padding(32)
+                if isShowingSettings {
+                    SettingsDetailView()
+                        .transition(.opacity)
+                        .background(Color(.systemBackground))
                 }
             }
         }
@@ -369,6 +378,11 @@ struct HomeView: View {
             }
             .padding()
             .frame(minWidth: 320)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .showSettings)) { _ in
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isShowingSettings = true
+            }
         }
     }
     
@@ -700,10 +714,6 @@ struct HomeView: View {
     }
 }
 
-#Preview(traits: .landscapeLeft) {
-    HomeView()
-}
-
 // MARK: - Korean-aware fuzzy search (Hangul Jamo subsequence)
 private func matches(_ text: String, query: String) -> Bool {
     let t = text.lowercased()
@@ -864,4 +874,8 @@ private func relativeDate(_ date: Date) -> String {
     let f = RelativeDateTimeFormatter()
     f.unitsStyle = .full
     return f.localizedString(for: date, relativeTo: Date())
+}
+
+extension Notification.Name {
+    static let showSettings = Notification.Name("ShowSettings")
 }

--- a/learningTool/Views/HomeView/SettingView.swift
+++ b/learningTool/Views/HomeView/SettingView.swift
@@ -1,158 +1,44 @@
 import SwiftUI
 import SwiftData
 
-struct SettingView: View {
+struct SettingsDetailView: View {
     @State private var isHelpPresented: Bool = false
     @State private var isFolderDeletePresented: Bool = false
     @State private var folderIDsPendingDelete = Set<PersistentIdentifier>()
-    @State private var selectedTheme: ThemeOption = .system
-    @State private var selectedLanguage: LanguageOption = .korean
+    @State private var selectedTheme: SettingView.ThemeOption = .system
+    @State private var selectedLanguage: SettingView.LanguageOption = .korean
     
     @Environment(\.modelContext) private var modelContext
     @Query private var folders: [Folder]
     @Query private var notes: [Note]
     
-    enum ThemeOption {
-        case system, light, dark
-    }
-    
-    enum LanguageOption {
-        case korean, english
-    }
-    
     var body: some View {
-        NavigationSplitView {
-            SidebarView(onFolderSelected: { _ in }, isHelpPresented: $isHelpPresented, requestDeleteConfirmation: { ids in
-                folderIDsPendingDelete = ids
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    isFolderDeletePresented = true
-                }
-            })
-            .navigationSplitViewColumnWidth(min: 280, ideal: 320, max: 400)
-            .toolbar(.hidden, for: .navigationBar)
-        } detail: {
-            VStack(spacing: 0) {
-                // 헤더
-                HStack {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("SWAI")
-                            .font(.system(size: 28, weight: .semibold))
-                            .foregroundStyle(Color.text1)
-                        
-                        Text("설정")
-                            .font(.system(size: 22, weight: .medium))
-                            .foregroundStyle(Color.text2)
-                    }
+        VStack(spacing: 0) {
+            // 헤더
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("SWAI")
+                        .font(.system(size: 28, weight: .semibold))
+                        .foregroundStyle(Color.text1)
                     
-                    Spacer()
+                    Text("설정")
+                        .font(.system(size: 22, weight: .medium))
+                        .foregroundStyle(Color.text2)
                 }
-                .padding(.horizontal, 24)
-                .padding(.top, 12)
-                .padding(.bottom, 16)
                 
-                // 메인 설정 영역
-                ScrollView {
+                Spacer()
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 12)
+            .padding(.bottom, 16)
+            
+            // 메인 설정 영역
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    // 기본 설정 섹션
                     VStack(alignment: .leading, spacing: 20) {
-                        // 기본 설정 섹션
-                        VStack(alignment: .leading, spacing: 20) {
-                            VStack(alignment: .leading, spacing: 16) {
-                                Text("기본 설정")
-                                    .font(.system(size: 20, weight: .semibold))
-                                    .foregroundStyle(Color.text1)
-                                
-                                // 구분선
-                                Rectangle()
-                                    .fill(Color.borderColor)
-                                    .frame(height: 1)
-                            }
-                            
-                            // 테마 설정
-                            HStack(alignment: .top, spacing: 20) {
-                                VStack(alignment: .leading, spacing: 4) {
-                                    Text("테마")
-                                        .font(.system(size: 16, weight: .medium))
-                                        .foregroundStyle(Color.text1)
-                                    Text("내 기기에서 SWAI의 모습을 바꿔보세요!")
-                                        .font(.system(size: 14, weight: .regular))
-                                        .foregroundStyle(Color.text3)
-                                }
-                                
-                                Spacer()
-                                
-                                HStack(spacing: 4) {
-                                    ThemeButton(
-                                        title: "시스템 설정 사용",
-                                        isSelected: selectedTheme == .system
-                                    ) {
-                                        selectedTheme = .system
-                                    }
-                                    
-                                    ThemeButton(
-                                        title: "라이트 모드",
-                                        isSelected: selectedTheme == .light
-                                    ) {
-                                        selectedTheme = .light
-                                    }
-                                    
-                                    ThemeButton(
-                                        title: "다크 모드",
-                                        isSelected: selectedTheme == .dark
-                                    ) {
-                                        selectedTheme = .dark
-                                    }
-                                }
-                                .padding(4)
-                                .background(Color.background2)
-                                .cornerRadius(18)
-                                .frame(width: 370, height: 36)
-                            }
-                            
-                            // 언어 설정
-                            HStack(alignment: .top, spacing: 20) {
-                                VStack(alignment: .leading, spacing: 4) {
-                                    Text("언어")
-                                        .font(.system(size: 16, weight: .medium))
-                                        .foregroundStyle(Color.text1)
-                                    Text("{%app_name}으로 학습할 언어를 설정해세요!")
-                                        .font(.system(size: 14, weight: .regular))
-                                        .foregroundStyle(Color.text3)
-                                }
-                                
-                                Spacer()
-                                
-                                HStack(spacing: 4) {
-                                    LanguageButton(
-                                        title: "한국어 (Korean)",
-                                        isSelected: selectedLanguage == .korean
-                                    ) {
-                                        selectedLanguage = .korean
-                                    }
-                                    
-                                    LanguageButton(
-                                        title: "영어 (English)",
-                                        isSelected: selectedLanguage == .english
-                                    ) {
-                                        selectedLanguage = .english
-                                    }
-                                }
-                                .padding(4)
-                                .background(Color.background2)
-                                .cornerRadius(18)
-                                .frame(width: 370, height: 36)
-                            }
-                        }
-                    }
-                    .padding(.horizontal, 24)
-                    .padding(.top, 12)
-                    .padding(.bottom, 24)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                
-                // 푸터 영역 (Caution!)
-                VStack(spacing: 0) {
-                    VStack(alignment: .leading, spacing: 16) {
                         VStack(alignment: .leading, spacing: 16) {
-                            Text("Caution!")
+                            Text("기본 설정")
                                 .font(.system(size: 20, weight: .semibold))
                                 .foregroundStyle(Color.text1)
                             
@@ -162,39 +48,107 @@ struct SettingView: View {
                                 .frame(height: 1)
                         }
                         
-                        HStack {
+                        // 테마 설정
+                        HStack(alignment: .top, spacing: 20) {
                             VStack(alignment: .leading, spacing: 4) {
-                                Text("노트 초기화")
+                                Text("테마")
                                     .font(.system(size: 16, weight: .medium))
                                     .foregroundStyle(Color.text1)
-                                Text("{%app_name}에서 작성한 모든 노트가 초기화 됩니다.")
+                                Text("내 기기에서 SWAI의 모습을 바꿔보세요!")
                                     .font(.system(size: 14, weight: .regular))
                                     .foregroundStyle(Color.text3)
                             }
                             
                             Spacer()
                             
-                            Button {
-                                // 노트 초기화 로직
-                            } label: {
-                                Text("초기화")
-                                    .font(.system(size: 14, weight: .medium))
-                                    .foregroundStyle(Color.errorColor)
-                                    .padding(.horizontal, 20)
-                                    .padding(.vertical, 8)
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: 8)
-                                            .stroke(Color.borderColor, lineWidth: 1)
-                                    )
+                            HStack(spacing: 4) {
+                                ThemeButton(title: "시스템 설정 사용", isSelected: selectedTheme == .system) { selectedTheme = .system }
+                                ThemeButton(title: "라이트 모드",   isSelected: selectedTheme == .light)  { selectedTheme = .light }
+                                ThemeButton(title: "다크 모드",     isSelected: selectedTheme == .dark)   { selectedTheme = .dark }
                             }
-                            .buttonStyle(.plain)
+                            .padding(4)
+                            .background(Color.background2)
+                            .cornerRadius(18)
+                            .frame(width: 370, height: 36)
+                        }
+                        
+                        // 언어 설정
+                        HStack(alignment: .top, spacing: 20) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("언어")
+                                    .font(.system(size: 16, weight: .medium))
+                                    .foregroundStyle(Color.text1)
+                                Text("{%app_name}으로 학습할 언어를 설정해세요!")
+                                    .font(.system(size: 14, weight: .regular))
+                                    .foregroundStyle(Color.text3)
+                            }
+                            
+                            Spacer()
+                            
+                            HStack(spacing: 4) {
+                                LanguageButton(title: "한국어 (Korean)", isSelected: selectedLanguage == .korean)  { selectedLanguage = .korean }
+                                LanguageButton(title: "영어 (English)",  isSelected: selectedLanguage == .english) { selectedLanguage = .english }
+                            }
+                            .padding(4)
+                            .background(Color.background2)
+                            .cornerRadius(18)
+                            .frame(width: 370, height: 36)
                         }
                     }
-                    .padding(24)
                 }
+                .padding(.horizontal, 24)
+                .padding(.top, 12)
+                .padding(.bottom, 24)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            
+            // 푸터 영역 (Caution!)
+            VStack(spacing: 0) {
+                VStack(alignment: .leading, spacing: 16) {
+                    VStack(alignment: .leading, spacing: 16) {
+                        Text("Caution!")
+                            .font(.system(size: 20, weight: .semibold))
+                            .foregroundStyle(Color.text1)
+                        
+                        // 구분선
+                        Rectangle()
+                            .fill(Color.borderColor)
+                            .frame(height: 1)
+                    }
+                    
+                    HStack {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("노트 초기화")
+                                .font(.system(size: 16, weight: .medium))
+                                .foregroundStyle(Color.text1)
+                            Text("{%app_name}에서 작성한 모든 노트가 초기화 됩니다.")
+                                .font(.system(size: 14, weight: .regular))
+                                .foregroundStyle(Color.text3)
+                        }
+                        
+                        Spacer()
+                        
+                        Button {
+                            // 노트 초기화 로직
+                        } label: {
+                            Text("초기화")
+                                .font(.system(size: 14, weight: .medium))
+                                .foregroundStyle(Color.errorColor)
+                                .padding(.horizontal, 20)
+                                .padding(.vertical, 8)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .stroke(Color.borderColor, lineWidth: 1)
+                                )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(24)
             }
         }
-        .navigationSplitViewStyle(.balanced)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemBackground))
         .overlay {
             if isFolderDeletePresented {
                 FolderDeleteView(
@@ -222,6 +176,21 @@ struct SettingView: View {
     }
 }
 
+struct SettingView: View {
+    enum ThemeOption { case system, light, dark }
+    enum LanguageOption { case korean, english }
+    
+    var body: some View {
+        NavigationSplitView {
+            SidebarView(onFolderSelected: { _ in }, isHelpPresented: .constant(false), requestDeleteConfirmation: { _ in })
+                .navigationSplitViewColumnWidth(min: 280, ideal: 320, max: 400)
+                .toolbar(.hidden, for: .navigationBar)
+        } detail: {
+            SettingsDetailView()
+        }
+    }
+}
+            
 // 테마 버튼 컴포넌트
 struct ThemeButton: View {
     let title: String


### PR DESCRIPTION
[pull_request_template.md](https://github.com/user-attachments/files/22903669/pull_request_template.md)
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #70 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 새로운 컴포넌트 `SettingView`의 기능 연결
- 다크모드 적용
- 

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->



---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] 설정 ZStack 열림
- [ ] 다크모드 테스트 후 텍스트가 어두운 문제

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 홈뷰 설정을 누르면 바뀌는 형식
- 다크모드시 어색하다
- 돌아갈 때 사이드바의 전체보기를 눌러야 돌아와짐

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- 세팅뷰
- 
