### PR TITLE
✨ Feature: #75 설정의 노트 초기화시, 리셋 오버레이 띄우기

### DIFF
--- a/learningTool/Views/HomeView/HomeView.swift
+++ b/learningTool/Views/HomeView/HomeView.swift
@@ -318,8 +318,18 @@ struct HomeView: View {
                         ResetConfirmAlertView(
                             isPresented: $showResetConfirm,
                             onConfirm: {
-                                // TODO: 실제 초기화 로직 연동 예정 — 현재는 닫기만 수행
-                                withAnimation(.easeInOut(duration: 0.2)) { showResetConfirm = false }
+                                // Delete all notes stored in SwiftData
+                                for note in notes {
+                                    modelContext.delete(note)
+                                }
+                                do {
+                                    try modelContext.save()
+                                } catch {
+                                    print("⚠️ Failed to delete all notes: \(error)")
+                                }
+                                withAnimation(.easeInOut(duration: 0.2)) {
+                                    showResetConfirm = false
+                                }
                             }
                         )
                         .frame(

--- a/learningTool/Views/HomeView/HomeView.swift
+++ b/learningTool/Views/HomeView/HomeView.swift
@@ -51,6 +51,7 @@ struct HomeView: View {
     @State private var isShowingSettings: Bool = false
     @State private var isFolderDeletePresented: Bool = false
     @State private var folderIDsPendingDelete = Set<PersistentIdentifier>()
+    @State private var showResetConfirm: Bool = false
 
     var body: some View {
         NavigationSplitView {
@@ -277,7 +278,7 @@ struct HomeView: View {
                     }
                 }
                 if isShowingSettings {
-                    SettingsDetailView()
+                    SettingsDetailView(showResetConfirm: $showResetConfirm)
                         .transition(.opacity)
                         .background(Color(.systemBackground))
                 }
@@ -300,6 +301,32 @@ struct HomeView: View {
                             .background(Color.background1)
                             .cornerRadius(20)
                             .shadow(color: Color.black.opacity(0.25), radius: 18, x: 0, y: 10)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .transition(.opacity.combined(with: .scale))
+                }
+            }
+        }
+        .overlay {
+            if showResetConfirm {
+                GeometryReader { geo in
+                    ZStack {
+                        Color.black.opacity(0.35)
+                            .ignoresSafeArea()
+                            .onTapGesture { withAnimation(.easeInOut(duration: 0.2)) { showResetConfirm = false } }
+
+                        ResetConfirmAlertView(
+                            isPresented: $showResetConfirm,
+                            onConfirm: {
+                                // TODO: 실제 초기화 로직 연동 예정 — 현재는 닫기만 수행
+                                withAnimation(.easeInOut(duration: 0.2)) { showResetConfirm = false }
+                            }
+                        )
+                        .frame(
+                            width: min(420, geo.size.width * 0.70),
+                            height: 340
+                        )
+                        .shadow(color: Color.black.opacity(0.25), radius: 18, x: 0, y: 10)
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .transition(.opacity.combined(with: .scale))

--- a/learningTool/Views/HomeView/SettingView.swift
+++ b/learningTool/Views/HomeView/SettingView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import SwiftData
 
 struct SettingsDetailView: View {
+    @Binding var showResetConfirm: Bool
     @State private var isHelpPresented: Bool = false
     @State private var isFolderDeletePresented: Bool = false
     @State private var folderIDsPendingDelete = Set<PersistentIdentifier>()
@@ -129,7 +130,7 @@ struct SettingsDetailView: View {
                         Spacer()
                         
                         Button {
-                            // 노트 초기화 로직
+                            withAnimation(.easeInOut(duration: 0.2)) { showResetConfirm = true }
                         } label: {
                             Text("초기화")
                                 .font(.system(size: 14, weight: .medium))
@@ -179,6 +180,7 @@ struct SettingsDetailView: View {
 struct SettingView: View {
     enum ThemeOption { case system, light, dark }
     enum LanguageOption { case korean, english }
+    @State private var showResetConfirm: Bool = false
     
     var body: some View {
         NavigationSplitView {
@@ -186,7 +188,7 @@ struct SettingView: View {
                 .navigationSplitViewColumnWidth(min: 280, ideal: 320, max: 400)
                 .toolbar(.hidden, for: .navigationBar)
         } detail: {
-            SettingsDetailView()
+            SettingsDetailView(showResetConfirm: $showResetConfirm)
         }
     }
 }
@@ -229,8 +231,106 @@ struct LanguageButton: View {
     }
 }
 
+// MARK: - Reset Confirm Alert (Centered Card)
+struct ResetConfirmAlertView: View {
+    @Binding var isPresented: Bool
+    var onConfirm: (() -> Void)? = nil
+
+    @State private var confirmationText: String = ""
+    private let requiredText = "초기화를 진행 하겠습니다."
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Title & description
+            VStack(alignment: .leading, spacing: 12) {
+                Text("모든 노트가 초기화 됩니다!")
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundStyle(Color.text1)
+
+                Text("이 작업은 실행 이후 복구할 수 없습니다.")
+                    .font(.system(size: 14))
+                    .foregroundStyle(Color.text2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 20)
+            .padding(.top, 22)
+
+            Spacer(minLength: 8)
+
+            // Input area
+            VStack(alignment: .leading, spacing: 0) {
+                Text(requiredText)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(Color.text1)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Divider().background(Color.borderColor).padding(.vertical, 10)
+
+                TextField("위 문장을 입력하세요.", text: $confirmationText, axis: .horizontal)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+                    .font(.system(size: 15))
+                    .foregroundStyle(Color.text1)
+                    .padding(.vertical, 8)
+            }
+            .padding(16)
+            .background(Color.background2)
+            .cornerRadius(14)
+            .padding(.horizontal, 20)
+
+            Spacer(minLength: 8)
+
+            // Buttons
+            HStack(spacing: 12) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) { isPresented = false }
+                } label: {
+                    Text("취소")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(Color.text1)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(Color.gray.opacity(0.2))
+                        .cornerRadius(14)
+                }
+                .buttonStyle(.plain)
+
+                Button {
+                    onConfirm?()
+                } label: {
+                    Text("초기화")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(isValid ? Color.errorColor : Color.text3.opacity(0.5))
+                        .cornerRadius(14)
+                }
+                .buttonStyle(.plain)
+                .disabled(!isValid)
+            }
+            .padding(.horizontal, 20)
+            .padding(.bottom, 16)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .frame(width: 360, height: 330)
+        .background(Color(.systemBackground))
+        .cornerRadius(20)
+        .overlay(RoundedRectangle(cornerRadius: 20).stroke(Color.borderColor, lineWidth: 1))
+    }
+
+    private var isValid: Bool {
+        confirmationText.trimmingCharacters(in: .whitespacesAndNewlines) == requiredText
+    }
+}
+
 #Preview(traits: .landscapeLeft) {
     SettingView()
+}
+
+#Preview(traits: .landscapeLeft) {
+    SettingsDetailView(showResetConfirm: .constant(false))
 }
 
 


### PR DESCRIPTION
[pull_request_template.md](https://github.com/user-attachments/files/22903669/pull_request_template.md)
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #75 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 리셋뷰 원본의 코드를 세팅뷰에 탑재
- 

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 초기화 알림뷰 오버레이 
- [x] 초기화 기능

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 초기화 버튼 클릭시 알림
- 

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- 세팅뷰 로직 변경
- 홈뷰 로직 변경
