### PR TITLE
Bug: #90 저장된 키워드로 고정시키기

### DIFF
--- a/learningTool/ViewModels/CaptionAnalyzer/CaptionAnalyzerViewModel.swift
+++ b/learningTool/ViewModels/CaptionAnalyzer/CaptionAnalyzerViewModel.swift
@@ -490,9 +490,10 @@ final class CaptionAnalyzer: ObservableObject {
                     guard sid == self.sessionId else { return }
                     self.finalSummary = merged.trimmingCharacters(in: .whitespacesAndNewlines)
                     self.isMergingFinal = false
-                    // finalSummary 기반 키워드 추출
+                    // NOTE: Final (extracted) keywords are computed for runtime display only and are not persisted.
                     self.extractedKeywords = self.extractKeywords()
-                    self.persistCacheToBoundNoteIfPossible()    }
+                    self.persistCacheToBoundNoteIfPossible()
+                }
                 self.log.info("sum[\(runTag)] merge done")
             } catch {
                 let ns = error as NSError
@@ -854,7 +855,7 @@ final class CaptionAnalyzer: ObservableObject {
     @MainActor
     private func persistCacheToBoundNoteIfPossible() {
         guard let note = self.boundNote else { return }
-        
+
         // 챕터 → 캐시 모델로 스냅샷
         var snapshot: [CachedChapter] = []
         for ch in self.chapters {
@@ -863,17 +864,19 @@ final class CaptionAnalyzer: ObservableObject {
                                           bullets: Array(bullets.prefix(4))))
         }
         note.cachedChapters = snapshot
-        
+
         note.cachedSummaryLines = self.summaryText
             .replacingOccurrences(of: "\r\n", with: "\n")
             .replacingOccurrences(of: "\r", with: "\n")
             .components(separatedBy: "\n")
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
-        
+
         note.cachedFinalSummary = self.finalSummary.isEmpty ? nil : self.finalSummary
-        note.cachedKeywords = self.extractedKeywords
-        
+        // Persist only chapter-derived keywords (progressive). Do NOT persist final extracted keywords.
+        let chapterKeywords = !self.accumulatedKeywords.isEmpty ? self.accumulatedKeywords : self.displayKeywords
+        note.cachedKeywords = Array(chapterKeywords.prefix(40))
+
         // ⚠️ 실제 디스크 저장은 View 레벨에서 `try? modelContext.save()` 호출로 마무리해주세요.
     }
     


### PR DESCRIPTION
[pull_request_template.md](https://github.com/user-attachments/files/22903669/pull_request_template.md)
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #90 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- CaptionAnalyzerViewModel.swift파일의 `CaptionAnalyzer`클래스 수정
- 
- 

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] 마지막 챕터까지 키워드 도출이 끝나면 다시 켰을 때 모두 저장된 상태로 유지
- [ ] 챕터 중간에 껐다가 키면, 해당 챕터까지만 키워드가 남고, 이후는 추가해서 저장하는걸로.

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 파싱요약 -> 챕터별 2차 요약 후 저장, 최종요약 후 키워드 새로 도출하는 문제.
- 

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- CaptionAnalyzerViewModel.swift파일의 `CaptionAnalyzer`클래스 수정
- 
