### PR TITLE
#feat/#94 create note view&study view

### DIFF
--- a/learningTool/Views/HomeView/CreateNoteView.swift
+++ b/learningTool/Views/HomeView/CreateNoteView.swift
@@ -12,38 +12,49 @@ struct CreateNoteView: View {
     @Binding var youtubeLink: String
     @Binding var noteTitle: String
     
+    // 디바이스 타입 감지
+    private var isIPad: Bool {
+        UIDevice.current.userInterfaceIdiom == .pad
+    }
+    
     var body: some View {
-        VStack(spacing: 0) {
-            // YouTube 링크
-            TextField("", text: $youtubeLink, prompt: Text("YouTube 링크를 입력하세요!")
-                .foregroundColor(Color.text3), axis: .horizontal)
-                .font(.system(size: 16))
-                .foregroundStyle(Color.text1)
-                .lineLimit(1)
-                .padding(.horizontal, 24)
-                .frame(height: 60)
+        GeometryReader { geometry in
+            VStack(spacing: 0) {
+                // YouTube 링크
+                TextField("", text: $youtubeLink, prompt: Text("YouTube 링크를 입력하세요!")
+                    .foregroundColor(Color.text3), axis: .horizontal)
+                    .font(.system(size: 16))
+                    .foregroundStyle(Color.text1)
+                    .lineLimit(1)
+                    .padding(.horizontal, 24)
+                    .frame(height: 60)
 
-            Divider()
-                .background(Color.borderColor)
+                Divider()
+                    .background(Color.borderColor)
 
-            // 제목
-            TextField("", text: $noteTitle, prompt: Text("저장할 노트 제목을 입력하세요!")
-                .foregroundColor(Color.text3), axis: .horizontal)
-                .font(.system(size: 16))
-                .foregroundStyle(Color.text1)
-                .lineLimit(1)
-                .padding(.horizontal, 24)
-                .frame(height: 60)
-        }
-        .frame(width: 663)
-        .background(
-            RoundedRectangle(cornerRadius: 16)
-                .fill(Color.background1)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 16)
-                        .stroke(Color.borderColor, lineWidth: 1)
-                )
+                // 제목
+                TextField("", text: $noteTitle, prompt: Text("저장할 노트 제목을 입력하세요!")
+                    .foregroundColor(Color.text3), axis: .horizontal)
+                    .font(.system(size: 16))
+                    .foregroundStyle(Color.text1)
+                    .lineLimit(1)
+                    .padding(.horizontal, 24)
+                    .frame(height: 60)
+            }
+            .frame(
+                width: min(isIPad ? 663 : geometry.size.width * 0.9, geometry.size.width - 48),
+                height: 120
             )
-        .shadow(color: Color.black.opacity(0.1), radius: 10, x: 0, y: 4)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(Color.background1)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16)
+                            .stroke(Color.borderColor, lineWidth: 1)
+                    )
+                )
+            .shadow(color: Color.black.opacity(0.1), radius: 10, x: 0, y: 4)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        }
     }
 }

--- a/learningTool/Views/StudyView/StudyView.swift
+++ b/learningTool/Views/StudyView/StudyView.swift
@@ -121,6 +121,15 @@ struct StudyView: View {
     @State private var leftTopRatio: CGFloat = 0.7     // left column top fraction
     @State private var rightTopRatio: CGFloat = 0.6    // right column top fraction
     
+    // iPhone 전용 collapse 상태
+    @State private var isPhoneSummaryCollapsed: Bool = false
+    @State private var isPhoneQuestionCollapsed: Bool = false
+    
+    // 디바이스 타입 감지
+    private var isIPad: Bool {
+        UIDevice.current.userInterfaceIdiom == .pad
+    }
+    
     
     init(note: Note? = nil, onDismiss: (() -> Void)? = nil) {
         _viewModel = StateObject(wrappedValue: StudyViewModel(note: note))
@@ -173,9 +182,69 @@ struct StudyView: View {
             Divider()
                 .background(Color.borderColor)
             
-            /// 메인 콘텐츠 (2열 레이아웃)
+            /// 메인 콘텐츠 (디바이스별 레이아웃)
             GeometryReader { geometry in
-                HStack(spacing: 0) {
+                if isIPad {
+                    // iPad: 기존 2열 레이아웃
+                    iPadLayout(geometry: geometry)
+                } else {
+                    // iPhone: 단일 컬럼 세로 레이아웃
+                    iPhoneLayout(geometry: geometry)
+                }
+            }
+        }
+        .background(Color.background2)
+        .keyboardOverlay()
+        // ▼ 전역 입력 바: 키보드 상단(StudyView 전체 너비) — 키보드 높이에 맞춰 자동 패딩
+        .overlay(alignment: .bottom) {
+            if showGlobalQuestionBar {
+                VStack(spacing: 0) {
+                    Divider().background(Color.borderColor)
+                    QuestionInputBar(
+                        text: $questionVM.currentMessage,
+                        isEnabled: GeminiAPIService.shared.isAPIKeyConfigured() && !questionVM.isLoading,
+                        isSending: questionVM.isLoading,
+                        isGenerating: false,
+                        focus: $globalQuestionFocus,
+                        placeholder: GeminiAPIService.shared.isAPIKeyConfigured() ? "메시지를 입력하세요" : "API 키를 먼저 설정해주세요",
+                        onTapLightbulb: { /* 전역 전구 버튼 필요 시 구현 */ },
+                        onSend: {
+                            if GeminiAPIService.shared.isAPIKeyConfigured() {
+                                questionVM.sendMessage()
+                                // 전송/접기 시 전역 바 닫기
+                                globalQuestionFocus = false
+                                showGlobalQuestionBar = false
+                            }
+                        }
+                    )
+                    .padding(16)
+                }
+                .background(Color.background1)
+                .keyboardAdaptivePadding() // 키보드 높이만큼 위로 올리기
+                .zIndex(1000)
+                .onAppear { globalQuestionFocus = true } // 전역 바 등장 시 포커스
+                .onChange(of: globalQuestionFocus) { _, focused in // 키보드 접힘 → 전역 바 닫기
+                    if !focused { showGlobalQuestionBar = false }
+                }
+            }
+        }
+        .onAppear { captionAnalyzer.autoSummarizeEnabled = true }
+        .onChange(of: captionAnalyzer.summaryStatus) { _, newValue in
+            if case .ready = newValue {
+                // CaptionAnalyzer가 바인딩된 Note에 캐시를 써 둔 뒤,
+                // 컨텍스트를 저장하여 영구화
+                try? modelContext.save()
+            }
+        }
+        .sheet(isPresented: $showingAPISettings) {
+            APISettingsView()
+        }
+    }
+    
+    // MARK: - iPad Layout
+    @ViewBuilder
+    private func iPadLayout(geometry: GeometryProxy) -> some View {
+        HStack(spacing: 0) {
                     let handleW: CGFloat = 10
                     let handleH: CGFloat = 12
                     let availW = geometry.size.width - handleW
@@ -341,55 +410,57 @@ struct StudyView: View {
                         .frame(width: rightW)
                     }
                 }
-            }
-        }
-        .background(Color.background2)
-        .keyboardOverlay()
-        // ▼ 전역 입력 바: 키보드 상단(StudyView 전체 너비) — 키보드 높이에 맞춰 자동 패딩
-        .overlay(alignment: .bottom) {
-            if showGlobalQuestionBar {
-                VStack(spacing: 0) {
-                    Divider().background(Color.borderColor)
-                    QuestionInputBar(
-                        text: $questionVM.currentMessage,
-                        isEnabled: GeminiAPIService.shared.isAPIKeyConfigured() && !questionVM.isLoading,
-                        isSending: questionVM.isLoading,
-                        isGenerating: false,
-                        focus: $globalQuestionFocus,
-                        placeholder: GeminiAPIService.shared.isAPIKeyConfigured() ? "메시지를 입력하세요" : "API 키를 먼저 설정해주세요",
-                        onTapLightbulb: { /* 전역 전구 버튼 필요 시 구현 */ },
-                        onSend: {
-                            if GeminiAPIService.shared.isAPIKeyConfigured() {
-                                questionVM.sendMessage()
-                                // 전송/접기 시 전역 바 닫기
-                                globalQuestionFocus = false
-                                showGlobalQuestionBar = false
-                            }
-                        }
+    }
+    
+    // MARK: - iPhone Layout
+    @ViewBuilder
+    private func iPhoneLayout(geometry: GeometryProxy) -> some View {
+        let totalHeight = geometry.size.height
+        let mediaHeight = min(totalHeight * 0.3, geometry.size.width * 9 / 16) // 16:9 비율 또는 30% 높이
+        let collapsedHeight: CGFloat = 80
+        let summaryExpandedHeight: CGFloat = 250
+        let questionExpandedHeight: CGFloat = 300
+        
+        ScrollView {
+            VStack(spacing: 0) {
+                // MARK: MediaView (상단)
+                MediaView(note: viewModel.currentNote, videoURL: resolvedVideoURL)
+                    .frame(height: mediaHeight)
+                    .frame(maxWidth: .infinity)
+                
+                // MARK: KeywordView (중간)
+                KeywordView(analyzer: captionAnalyzer, studyViewModel: viewModel)
+                    .frame(minHeight: 200)
+                    .frame(maxWidth: .infinity)
+                
+                // MARK: SummaryView (하단 1, 접기 가능)
+                CollapsiblePane(
+                    isCollapsed: $isPhoneSummaryCollapsed,
+                    height: isPhoneSummaryCollapsed ? collapsedHeight : summaryExpandedHeight
+                ) {
+                    SummaryView()
+                        .frame(maxWidth: .infinity)
+                }
+                .frame(maxWidth: .infinity)
+                
+                // MARK: QuestionView (하단 2, 접기 가능)
+                CollapsiblePane(
+                    isCollapsed: $isPhoneQuestionCollapsed,
+                    height: isPhoneQuestionCollapsed ? collapsedHeight : questionExpandedHeight
+                ) {
+                    QuestionView(
+                        studyViewModel: viewModel,
+                        viewModel: questionVM,
+                        isGlobalInputActive: $showGlobalQuestionBar
                     )
-                    .padding(16)
+                    .frame(maxWidth: .infinity)
                 }
-                .background(Color.background1)
-                .keyboardAdaptivePadding() // 키보드 높이만큼 위로 올리기
-                .zIndex(1000)
-                .onAppear { globalQuestionFocus = true } // 전역 바 등장 시 포커스
-                .onChange(of: globalQuestionFocus) { _, focused in // 키보드 접힘 → 전역 바 닫기
-                    if !focused { showGlobalQuestionBar = false }
-                }
+                .frame(maxWidth: .infinity)
             }
-        }
-        .onAppear { captionAnalyzer.autoSummarizeEnabled = true }
-        .onChange(of: captionAnalyzer.summaryStatus) { _, newValue in
-            if case .ready = newValue {
-                // CaptionAnalyzer가 바인딩된 Note에 캐시를 써 둔 뒤,
-                // 컨텍스트를 저장하여 영구화
-                try? modelContext.save()
-            }
-        }
-        .sheet(isPresented: $showingAPISettings) {
-            APISettingsView()
         }
     }
+    
+    // MARK: - Helpers
     // 현재 노트의 유튜브 링크를 우선 사용하고,
     // 없으면 같은 제목의 노트를 SwiftData에서 찾아 링크를 사용합니다.
     private var resolvedVideoURL: String? {

--- a/learningTool/Views/StudyView/StudyView.swift
+++ b/learningTool/Views/StudyView/StudyView.swift
@@ -416,7 +416,22 @@ struct StudyView: View {
     @ViewBuilder
     private func iPhoneLayout(geometry: GeometryProxy) -> some View {
         let totalHeight = geometry.size.height
-        let mediaHeight = min(totalHeight * 0.3, geometry.size.width * 9 / 16) // 16:9 비율 또는 30% 높이
+        let totalWidth = geometry.size.width
+        
+        // 가로 모드 감지 (너비 > 높이)
+        let isLandscape = totalWidth > totalHeight
+        
+        // MediaView 높이 계산 (가로/세로 모드에 따라 다르게)
+        let mediaHeight: CGFloat = {
+            if isLandscape {
+                // 가로 모드: 화면 높이의 50% 사용, 최소 200pt 보장
+                return max(totalHeight * 0.5, 200)
+            } else {
+                // 세로 모드: 16:9 비율 또는 화면 높이의 30%
+                return min(totalHeight * 0.3, totalWidth * 9 / 16)
+            }
+        }()
+        
         let collapsedHeight: CGFloat = 80
         let summaryExpandedHeight: CGFloat = 250
         let questionExpandedHeight: CGFloat = 300


### PR DESCRIPTION
[pull_request_template.md](https://github.com/user-attachments/files/22903669/pull_request_template.md)
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #94 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 새로운 컴포넌트 `XxxView` 추가
- API 연동 로직 리팩토링
- 버그 수정: 홈 화면 진입 시 크래시

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="예시 이미지" src="https://...">

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 15, iOS 17.4 환경에서 정상 동작
- [ ] 다크모드 테스트는 이후 이슈로 분리 예정 (#000)

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- `XxxViewModel.swift` 파일의 로직 분리 구조
- `NetworkManager.swift`의 공통 로직 처리 방식
