### PR TITLE
🐛 Bug: #107 요약뷰 불릿 특수문자와 쉐브론 1종류만 표시되도록 하기

### DIFF
--- a/learningTool/ViewModels/CaptionAnalyzer/SummaizerEngine.swift
+++ b/learningTool/ViewModels/CaptionAnalyzer/SummaizerEngine.swift
@@ -84,17 +84,18 @@ final class SummarizerEngine {
             guard !trimmed.isEmpty else { continue }
             
             do {
-                let one = try await summarizer.summarizeChunk(
+                let raw = try await summarizer.summarizeChunk(
                     text: trimmed,
                     instruction: "아래 문단을 한국어로 한 문장 핵심 요약. 고유명사/숫자 유지. 군더더기 없이."
                 ).replacingOccurrences(of: "\n", with: " ")
-                linesOut.append("• " + one.trimmingCharacters(in: .whitespacesAndNewlines))
+                let clean = stripBulletPrefix(raw).trimmingCharacters(in: .whitespacesAndNewlines)
+                linesOut.append("• " + clean)
                 self.log.info("sum[\(runTag)] step \(i+1) ok")
                 await onSummaryProgress(i + 1, paragraphs.count)
             } catch {
                 let ns = error as NSError
                 self.log.error("sum[\(runTag)] step \(i+1) error: \(ns.localizedDescription, privacy: .public)")
-                linesOut.append("• " + firstLine(trimmed))
+                linesOut.append("• " + stripBulletPrefix(firstLine(trimmed)))
             }
             
             // UI에 간헐적으로 누적 반영 (시간 스로틀: 0.8s)
@@ -135,6 +136,17 @@ final class SummarizerEngine {
     
     private func firstLine(_ s: String) -> String {
         s.split(separator: "\n", maxSplits: 1).first.map(String.init) ?? s
+    }
+
+    /// Remove any leading bullet/dash so we can add a single "• " in step 4 only.
+    private func stripBulletPrefix(_ s: String) -> String {
+        var t = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        let prefixes = ["•", "-", "–", "—", "∙", "·", "●", "*"]
+        if let p = prefixes.first(where: { t.hasPrefix($0) }) {
+            t.removeFirst(p.count)
+            t = t.trimmingCharacters(in: .whitespaces)
+        }
+        return t
     }
     
     private func makeParagraphs(from chunks: [CueChunk], targetChars: Int = 600) -> [String] {

--- a/learningTool/Views/StudyView/SummaryView.swift
+++ b/learningTool/Views/StudyView/SummaryView.swift
@@ -107,10 +107,21 @@ struct SummaryView: View {
             return Summary(
                 id: ch.id,
                 title: title,
-                items: Array(bullets.prefix(4)),
+                items: Array(bullets.prefix(4)).map(stripBulletPrefix),
                 progress: "\(idx + 1) / \(total)"
             )
         }
+    }
+
+    /// UI에서 불릿 기호를 제거해 '불릿 없이 최대 4줄'을 보이도록 한다.
+    private func stripBulletPrefix(_ s: String) -> String {
+        var t = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        let prefixes = ["•", "-", "–", "—", "∙", "·", "●", "*"]
+        if let p = prefixes.first(where: { t.hasPrefix($0) }) {
+            t.removeFirst(p.count)
+            t = t.trimmingCharacters(in: .whitespaces)
+        }
+        return t
     }
 
     private func pagedChapters(_ list: [Summary]) -> some View {
@@ -163,7 +174,27 @@ private struct SummaryDisclosureCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            DisclosureGroup(isExpanded: $isExpanded) {
+            // Header row with custom chevron (no DisclosureGroup)
+            Button(action: {
+                withAnimation(.easeInOut(duration: 0.2)) { isExpanded.toggle() }
+            }) {
+                HStack {
+                    Text("#\(index). \(summary.title)")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(Color.text1)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 14))
+                        .foregroundStyle(Color.text3)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                        .animation(.easeInOut(duration: 0.2), value: isExpanded)
+                }
+                .contentShape(Rectangle()) // make the whole row tappable
+            }
+            .buttonStyle(.plain)
+
+            // Collapsible content
+            if isExpanded {
                 VStack(alignment: .leading, spacing: 8) {
                     ForEach(Array(summary.items.enumerated()), id: \.offset) { _, line in
                         HStack(alignment: .top, spacing: 8) {
@@ -176,19 +207,8 @@ private struct SummaryDisclosureCard: View {
                     }
                 }
                 .padding(.top, 8)
-            } label: {
-                HStack {
-                    Text("#\(index). \(summary.title)")
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(Color.text1)
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 14))
-                        .foregroundStyle(Color.text3)
-                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
-                }
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
-
         }
         .padding(16)
         .background(Color.background2)


### PR DESCRIPTION
🐛 Bug: 요약뷰 불릿 특수문자와 쉐브론 1종류만 표시되도록 하기 #107

[pull_request_template.md](https://github.com/user-attachments/files/22903669/pull_request_template.md)
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #107 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 요약 잡버그 해결
- 
- 

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

비뽀
<img width="1376" height="1032" alt="스크린샷, 2025-10-27 오후 11 06 38" src="https://github.com/user-attachments/assets/ce60465a-ca1f-4253-8bd8-48845163fbca" />

애푸타
<img width="1376" height="1032" alt="스크린샷, 2025-11-05 오후 11 36 32" src="https://github.com/user-attachments/assets/ddd650bb-68bd-45c3-b92e-1404f36c736f" />

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPad Pro 13" M4, iOS 26 환경에서 정상 동작
- 

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- <<이런거 -, * # 이런 기호 하나만 뜨게
- 글고 쉐브론 < < > 이런 꺾쇠 하나만 뜨게 함

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- `SummaizerEngine.swift`
- `SummaryView.swift` 변경됨
