### PR TITLE
♻️ Refactor: #128 iOS26 -> iOS18 이상으로 버전 분기처리 확대

### DIFF
--- a/learningTool.xcodeproj/project.pbxproj
+++ b/learningTool.xcodeproj/project.pbxproj
@@ -572,6 +572,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -604,6 +605,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/learningTool/ViewModels/CaptionAnalyzer/CaptionAnalyzerViewModel.swift
+++ b/learningTool/ViewModels/CaptionAnalyzer/CaptionAnalyzerViewModel.swift
@@ -240,8 +240,7 @@ final class CaptionAnalyzer: ObservableObject {
         guard autoSummarizeEnabled,
               case .ready = vttStatus,
               !vttCues.isEmpty,
-              summaryStatus == .idle,
-              summarizer != nil else { return }
+              summaryStatus == .idle else { return }
         log.info("startAutoSummarizeIfNeeded → firing (autoSummarizeEnabled=\(self.autoSummarizeEnabled), cues=\(self.vttCues.count))")
         Task { await summarizeFromCues(self.vttCues) }
     }
@@ -257,69 +256,68 @@ final class CaptionAnalyzer: ObservableObject {
             self.chapterTexts = [:]
             self.summaryDebug = SummaryDebug(runId: runId, processed: 0, total: 0, lastUpdate: Date())
         }
-        
+
         if sid != self.sessionId { return }
-        
-        guard let summarizer = self.summarizer else {
-            await MainActor.run {
-                self.summaryStatus = .failed("요약 모델 자산이 없습니다. (iOS 26+ 지원 기기·언어·지역 필요)")
-            }
-            return
-        }
-        
-        // SummarizerEngine에 위임
-        await summarizerEngine.processCues(
-            cues: cues,
-            sessionId: sid,
-            summarizer: summarizer,
-            runId: runId,
-            onChaptersBuilt: { [weak self] chapters, chapterTexts in
-                guard let self else { return }
-                await MainActor.run {
-                    self.chapters = chapters
-                    self.chapterTexts = chapterTexts
-                }
-            },
-            onChapterTitleUpdate: { [weak self] id, title in
-                guard let self else { return }
-                self.setChapterTitle(id: id, title: title)
-            },
-            onChapterGistUpdate: { [weak self] id, gist in
-                guard let self else { return }
-                self.setChapterGist(id: id, gist: gist)
-            },
-            onChapterBulletsUpdate: { [weak self] id, bullets in
-                guard let self else { return }
-                await MainActor.run {
-                    self.setChapterBullets(id: id, bullets: bullets)
-                }
-            },
-            onSummaryProgress: { [weak self] processed, total in
-                guard let self else { return }
-                await MainActor.run {
-                    self.summaryDebug.processed = processed
-                    self.summaryDebug.total = total
-                    self.summaryDebug.lastUpdate = Date()
-                }
-            },
-            onSummaryTextUpdate: { [weak self] text in
-                guard let self else { return }
-                await MainActor.run {
-                    withAnimation(.none) { self.summaryText = text }
-                }
-            },
-            onComplete: { [weak self] summaryLines in
-                guard let self else { return }
-                await MainActor.run {
-                    withAnimation(.none) {
-                        self.summaryText = summaryLines.joined(separator: "\n")
-                        self.summaryStatus = .ready
+
+        if let summarizer = self.summarizer {
+            // iOS 26+ (Apple Intelligence / FoundationModels 사용 가능 경로)
+            await summarizerEngine.processCues(
+                cues: cues,
+                sessionId: sid,
+                summarizer: summarizer,
+                runId: runId,
+                onChaptersBuilt: { [weak self] chapters, chapterTexts in
+                    guard let self else { return }
+                    await MainActor.run {
+                        self.chapters = chapters
+                        self.chapterTexts = chapterTexts
                     }
-                    self.summaryDebug.lastUpdate = Date()
+                },
+                onChapterTitleUpdate: { [weak self] id, title in
+                    guard let self else { return }
+                    self.setChapterTitle(id: id, title: title)
+                },
+                onChapterGistUpdate: { [weak self] id, gist in
+                    guard let self else { return }
+                    self.setChapterGist(id: id, gist: gist)
+                },
+                onChapterBulletsUpdate: { [weak self] id, bullets in
+                    guard let self else { return }
+                    await MainActor.run {
+                        self.setChapterBullets(id: id, bullets: bullets)
+                    }
+                },
+                onSummaryProgress: { [weak self] processed, total in
+                    guard let self else { return }
+                    await MainActor.run {
+                        self.summaryDebug.processed = processed
+                        self.summaryDebug.total = total
+                        self.summaryDebug.lastUpdate = Date()
+                    }
+                },
+                onSummaryTextUpdate: { [weak self] text in
+                    guard let self else { return }
+                    await MainActor.run {
+                        withAnimation(.none) { self.summaryText = text }
+                    }
+                },
+                onComplete: { [weak self] summaryLines in
+                    guard let self else { return }
+                    await MainActor.run {
+                        withAnimation(.none) {
+                            self.summaryText = summaryLines.joined(separator: "\n")
+                            self.summaryStatus = .ready
+                        }
+                        self.summaryDebug.lastUpdate = Date()
+                    }
+                    self.mergeFinalAsync(pieces: summaryLines, runTag: runId.uuidString.prefix(8), summarizer: summarizer, sessionId: sid)
                 }
-                self.mergeFinalAsync(pieces: summaryLines, runTag: runId.uuidString.prefix(8), summarizer: summarizer, sessionId: sid)
-            }
-        )
+            )
+        } else {
+            // iOS 18+ ~ 25.x: Summarizer(Apple Intelligence)가 없는 경우 휴리스틱 기반 Fallback
+            log.info("summarizeFromCues() fallback → using heuristic summarization (no Summarizer available)")
+            await fallbackSummarizeFromCues(cues, sid: sid, runId: runId)
+        }
     }
     
     private func mergeFinalAsync(pieces: [String], runTag: Substring, summarizer: Summarizer, sessionId sid: UUID) {
@@ -583,6 +581,99 @@ final class CaptionAnalyzer: ObservableObject {
                 self.log.error("tracks(error) \(error.localizedDescription, privacy: .public)")
                 self.vttStatus = .failed(error.localizedDescription)
             }
+        }
+    }
+    // MARK: - Fallback Summarization (iOS 18+ without Apple Intelligence)
+    /// Summarizer(AppleFMSummarizer 등)를 사용할 수 없는 환경에서
+    /// 자막 텍스트만으로 간단한 챕터/요약/키워드 정보를 생성하여
+    /// iOS 18+ 사용자에게도 유사한 UX를 제공한다.
+    private func fallbackSummarizeFromCues(_ cues: [VTTCue], sid: UUID, runId: UUID) async {
+        let fullText = cues
+            .map { $0.text }
+            .joined(separator: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+
+        guard !fullText.isEmpty else {
+            await MainActor.run {
+                guard sid == self.sessionId else { return }
+                self.summaryStatus = .failed("요약할 자막 데이터가 없습니다.")
+            }
+            return
+        }
+
+        // 자막 길이에 따라 2~6개 사이의 챕터로 단순 분할
+        let estimatedChapterCount = max(2, min(6, max(1, fullText.count / 800)))
+        let chapterCount = min(estimatedChapterCount, max(1, cues.count))
+        let chunkSize = max(1, cues.count / chapterCount)
+
+        var chapters: [Chapter] = []
+        var bulletsMap: [UUID: [String]] = [:]
+
+        let sentenceDelimiters = CharacterSet(charactersIn: ".?!。！？")
+        let sentences = fullText
+            .components(separatedBy: sentenceDelimiters)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        for (index, startIndex) in stride(from: 0, to: cues.count, by: chunkSize).enumerated() {
+            let endIndex = min(startIndex + chunkSize, cues.count)
+            let slice = cues[startIndex..<endIndex]
+            guard let first = slice.first, let last = slice.last else { continue }
+
+            let sliceText = slice
+                .map { $0.text }
+                .joined(separator: " ")
+
+            let sliceSentences = sliceText
+                .components(separatedBy: sentenceDelimiters)
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+
+            let titleBase = sliceSentences.first ?? "챕터 \(index + 1)"
+            let title = String(titleBase.prefix(40))
+            let gist = sliceSentences.prefix(2).joined(separator: " / ")
+            let bullets = Array(sliceSentences.prefix(4))
+
+            let chapter = Chapter(
+                start: first.start,
+                end: last.end,
+                title: title.isEmpty ? "챕터 \(index + 1)" : title,
+                gist: gist.isEmpty ? title : gist
+            )
+
+            chapters.append(chapter)
+            bulletsMap[chapter.id] = bullets
+        }
+
+        let summarySentences = Array(sentences.prefix(10))
+        let simpleSummary = summarySentences.joined(separator: " ")
+
+        // 키워드는 KeywordExtractor의 빈도 기반 로직 사용
+        let keywords = self.keywordExtractor.extractKeywords(from: fullText, topN: 10)
+
+        await MainActor.run {
+            guard sid == self.sessionId else { return }
+
+            self.chapters = chapters
+            self.chapterBullets = bulletsMap
+            self.chapterTexts = [:] // 휴리스틱 경로에서는 원문 맵을 사용하지 않음
+            self.summaryText = simpleSummary.isEmpty ? fullText : simpleSummary
+            self.finalSummary = self.summaryText
+            self.summaryStatus = .ready
+
+            self.extractedKeywords = keywords
+            self.displayKeywords = keywords
+            self.accumulatedKeywords = keywords
+
+            self.summaryDebug = SummaryDebug(
+                runId: runId,
+                processed: summarySentences.count,
+                total: sentences.count,
+                lastUpdate: Date()
+            )
+
+            self.persistCacheToBoundNoteIfPossible()
+            self.log.info("fallbackSummarizeFromCues() done; chapters=\(chapters.count), keywords=\(keywords.count)")
         }
     }
 }

--- a/learningTool/Views/HomeView/HomeView.swift
+++ b/learningTool/Views/HomeView/HomeView.swift
@@ -226,7 +226,7 @@ struct HomeView: View {
             .frame(minWidth: 220, maxWidth: 320)
             .frame(height: 36)
             .glassEffect()
-            .glassEffectUnion(id: "search", namespace: glassNS)
+            .glassEffectUnionCompat(id: "search", namespace: glassNS)
         }
     }
     
@@ -267,13 +267,13 @@ struct HomeView: View {
             .buttonStyle(.plain)
         } label: {
             GlassEffectContainer(spacing: 0) {
-                                    Image(systemName: "line.3.horizontal.decrease")
-                                        .font(.system(size: 16, weight: .semibold))
-                                        .frame(width: 36, height: 36)
-                                        .glassEffect()
-                                        .glassEffectUnion(id: "sort", namespace: glassNS)
-                                }
-                                .tint(Color.text2)
+                Image(systemName: "line.3.horizontal.decrease")
+                    .font(.system(size: 16, weight: .semibold))
+                    .frame(width: 36, height: 36)
+                    .glassEffect()
+                    .glassEffectUnionCompat(id: "sort", namespace: glassNS)
+            }
+            .tint(Color.text2)
         }
         // 기존 버튼 그림자 느낌 유지
         .shadow(color: .black.opacity(0.08), radius: 8, x: 0, y: 2)
@@ -471,6 +471,20 @@ extension HomeView {
                 }
             }
                             .keyboardOverlay()
+        }
+    }
+}
+
+// MARK: - Glass Effect Compatibility (iOS 18+ fallback)
+extension View {
+    /// iOS 26.0 이상에서는 glassEffectUnion을 적용하고,
+    /// 그 미만(iOS 18+ 등)에서는 기본 스타일을 유지하는 래퍼
+    @ViewBuilder
+    func glassEffectUnionCompat(id: String, namespace: Namespace.ID) -> some View {
+        if #available(iOS 26.0, *) {
+            self.glassEffectUnion(id: id, namespace: namespace)
+        } else {
+            self
         }
     }
 }

--- a/learningTool/Views/HomeView/SidebarView.swift
+++ b/learningTool/Views/HomeView/SidebarView.swift
@@ -397,7 +397,7 @@ struct SidebarView: View {
             }
         }
         .frame(width: 204, height: 145)
-        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .sidebarMenuGlassCompat()
         .presentationCompactAdaptation(.popover)
     }
 
@@ -503,5 +503,24 @@ struct SidebarView: View {
             Color.background1.ignoresSafeArea()
         }
         .navigationSplitViewStyle(.balanced)
+    }
+}
+
+// MARK: - Sidebar Glass Effect Compatibility
+extension View {
+    /// iOS 26.0 이상에서는 시스템 glassEffect를 사용하고,
+    /// 그 미만(iOS 18+ 등)에서는 불투명 카드 + 그림자 스타일로 대체
+    @ViewBuilder
+    func sidebarMenuGlassCompat() -> some View {
+        if #available(iOS 26.0, *) {
+            self.glassEffect(.regular, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        } else {
+            self
+                .background(
+                    Color.background2.opacity(0.98),
+                    in: RoundedRectangle(cornerRadius: 16, style: .continuous)
+                )
+                .shadow(color: Color.black.opacity(0.12), radius: 8, x: 0, y: 4)
+        }
     }
 }


### PR DESCRIPTION
[pull_request_template.md](https://github.com/user-attachments/files/22903669/pull_request_template.md)
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #128 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- iOS26은 기존의 글래스효과, 인텔리전스 성능을 발휘
- 최소 iOS18.x로 설정.
- iOS최소 ~ 25.x가 존재한다면 민짜 UI사용

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->



---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] iOS26 시뮬레이터 UI 정상 동작 확인
- [ ] 실기기 확인 필요


---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->



---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->


