### PR TITLE
🐛 Bug: #166 아이패드용 홈뷰 UX 다듬기 총괄2

### DIFF
--- a/AINO/Views/HomeView/HomeView.swift
+++ b/AINO/Views/HomeView/HomeView.swift
@@ -280,6 +280,24 @@ struct HomeView: View {
                     postOnboardingStep = .list
                 }
             }
+            .onReceive(NotificationCenter.default.publisher(for: .homeBackRequested)) { _ in
+                if let snap = backStack.popLast() {
+                    restore(from: snap)
+                } else {
+                    // 안전망: 스택이 비어있다면 Trash/Settings를 닫고 기본 화면으로
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        isShowingTrash = false
+                        isShowingSettings = false
+                        if selectedFolderName == "__ALL__" {
+                            headerSubtitle = "전체 보기"
+                        } else if selectedFolderName == nil {
+                            headerSubtitle = "최근 열어본 항목"
+                        } else {
+                            headerSubtitle = selectedFolderName ?? ""
+                        }
+                    }
+                }
+            }
             .onAppear {
                 // 앱 시작 직후 ‘전체 보기’로 진입 → + 버튼 보이게
                 if selectedFolderName == nil {
@@ -805,98 +823,104 @@ struct HomeView: View {
     }
     
     // MARK: - Sidebar Compact Menu Button (Liquid Glass)
+    @ViewBuilder
     private func sidebarMenuButton(metrics: LayoutMetrics) -> some View {
-        Menu {
-            // 전체 보기
-            Button {
-                applySelection(folderName: "__ALL__", subtitle: "전체 보기")
-            } label: {
-                Label("전체 보기", systemImage: "square.grid.2x2")
-            }
-            
-            // 최근 열어본 항목
-            Button {
-                applySelection(folderName: nil, subtitle: "최근 열어본 항목")
-            } label: {
-                Label("최근 열어본 항목", systemImage: "clock")
-            }
+        if horizontalSizeClass == .compact && (isShowingSettings || isShowingTrash) {
+            // 컴팩트에서 설정/휴지통 진입 시: 폴더와 동일한 뒤로가기 로직을 사용하는 버튼을 반환
+            backButton(metrics: metrics)
+        } else {
+            Menu {
+                // 전체 보기
+                Button {
+                    applySelection(folderName: "__ALL__", subtitle: "전체 보기")
+                } label: {
+                    Label("전체 보기", systemImage: "square.grid.2x2")
+                }
 
-            // 폴더 추가
-            Button {
-                createNewFolderAndSelect()
+                // 최근 열어본 항목
+                Button {
+                    applySelection(folderName: nil, subtitle: "최근 열어본 항목")
+                } label: {
+                    Label("최근 열어본 항목", systemImage: "clock")
+                }
+
+                // 폴더 추가
+                Button {
+                    createNewFolderAndSelect()
+                } label: {
+                    Label("새 폴더 만들기", systemImage: "folder.badge.plus")
+                }
+
+                // 폴더 목록
+                if !folders.isEmpty {
+                    Section("폴더") {
+                        ForEach(folders) { folder in
+                            Button {
+                                applySelection(folderName: folder.name, subtitle: folder.name)
+                            } label: {
+                                Label(folder.name, systemImage: "folder")
+                            }
+                        }
+                    }
+                }
+
+                // 도움말 / 설정 / 휴지통
+                Section {
+                    Button {
+                        // 설정으로 들어가기 직전 push
+                        pushCurrentSnapshot()
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            isShowingSettings = true
+                            isShowingTrash = false
+                            headerSubtitle = "설정"
+                        }
+                    } label: {
+                        Label("설정", systemImage: "gearshape")
+                    }
+
+                    Button {
+                        // 휴지통으로 들어가기 직전 push
+                        pushCurrentSnapshot()
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            isShowingTrash = true
+                            isShowingSettings = false
+                            headerSubtitle = "휴지통"
+                        }
+                    } label: {
+                        Label("휴지통", systemImage: "trash")
+                    }
+
+                    Button {
+                        isHelpPresented = true
+                    } label: {
+                        Label("도움말", systemImage: "questionmark.circle")
+                    }
+                }
             } label: {
-                Label("새 폴더 만들기", systemImage: "folder.badge.plus")
-            }
-            
-            // 폴더 목록
-            if !folders.isEmpty {
-                Section("폴더") {
-                    ForEach(folders) { folder in
-                        Button {
-                            applySelection(folderName: folder.name, subtitle: folder.name)
-                        } label: {
-                            Label(folder.name, systemImage: "folder")
+                Group {
+                    if horizontalSizeClass == .compact {
+                        ZStack {
+                            Circle()
+                                .fill(Color.background2.opacity(0.96))
+                                .frame(width: metrics.controlMinSide, height: metrics.controlMinSide)
+                            Image(systemName: "line.3.horizontal")
+                                .font(.system(size: 18, weight: .semibold))
+                                .foregroundStyle(Color.text2)
+                        }
+                        .contentShape(Circle())
+                    } else {
+                        GlassEffectContainer(spacing: 0) {
+                            Image(systemName: "line.3.horizontal")
+                                .font(.system(size: 18, weight: .semibold))
+                                .frame(width: metrics.menuButtonSide, height: metrics.menuButtonSide)
+                                .glassEffect()
+                                .glassEffectUnionCompat(id: "sidebar-menu", namespace: glassNS)
                         }
                     }
                 }
             }
-            
-            // 도움말 / 설정 / 휴지통
-            Section {
-                Button {
-                    // 설정으로 들어가기 직전 push
-                    pushCurrentSnapshot()
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        isShowingSettings = true
-                        isShowingTrash = false
-                        headerSubtitle = "설정"
-                    }
-                } label: {
-                    Label("설정", systemImage: "gearshape")
-                }
-                
-                Button {
-                    // 휴지통으로 들어가기 직전 push
-                    pushCurrentSnapshot()
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        isShowingTrash = true
-                        isShowingSettings = false
-                        headerSubtitle = "휴지통"
-                    }
-                } label: {
-                    Label("휴지통", systemImage: "trash")
-                }
-                
-                Button {
-                    isHelpPresented = true
-                } label: {
-                    Label("도움말", systemImage: "questionmark.circle")
-                }
-            }
-        } label: {
-            Group {
-                if horizontalSizeClass == .compact {
-                    ZStack {
-                        Circle()
-                            .fill(Color.background2.opacity(0.96))
-                            .frame(width: metrics.controlMinSide, height: metrics.controlMinSide)
-                        Image(systemName: "line.3.horizontal")
-                            .font(.system(size: 18, weight: .semibold))
-                            .foregroundStyle(Color.text2)
-                    }
-                    .contentShape(Circle())
-                } else {
-                    GlassEffectContainer(spacing: 0) {
-                        Image(systemName: "line.3.horizontal")
-                            .font(.system(size: 18, weight: .semibold))
-                            .frame(width: metrics.menuButtonSide, height: metrics.menuButtonSide)
-                            .glassEffect()
-                            .glassEffectUnionCompat(id: "sidebar-menu", namespace: glassNS)
-                    }
-                }
-            }
+            .buttonStyle(.plain)
         }
-        .buttonStyle(.plain)
     }
     
     // MARK: - Actions

--- a/AINO/Views/HomeView/SettingView.swift
+++ b/AINO/Views/HomeView/SettingView.swift
@@ -18,6 +18,7 @@ struct SettingsDetailView: View {
     @Query private var folders: [Folder]
     @Query private var notes: [Note]
     @EnvironmentObject private var learningLogStore: LearningLogStore
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     
     // 테마를 ColorScheme으로 변환
     private var colorScheme: ColorScheme? {
@@ -31,22 +32,59 @@ struct SettingsDetailView: View {
     var body: some View {
         VStack(spacing: 0) {
             // 헤더
-            HStack {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("AINO")
-                        .font(.system(size: 28, weight: .semibold))
-                        .foregroundStyle(Color.text1)
-                    
-                    Text("설정")
-                        .font(.system(size: 22, weight: .medium))
-                        .foregroundStyle(Color.text2)
+            Group {
+                if horizontalSizeClass == .compact {
+                    // 📱 iPhone 스타일: 뒤로가기 + 제목 한 줄, 홈뷰 컴팩트 헤더 여백과 유사
+                    HStack(spacing: 8) {
+                        // 뒤로가기 버튼
+                        Button {
+                            NotificationCenter.default.post(name: .homeBackRequested, object: nil)
+                        } label: {
+                            ZStack {
+                                Circle()
+                                    .fill(Color.background2.opacity(0.96))
+                                    .frame(width: 44, height: 44)
+                                Image(systemName: "chevron.left")
+                                    .font(.system(size: 18, weight: .semibold))
+                                    .foregroundStyle(Color.text2)
+                            }
+                            .contentShape(Circle())
+                        }
+                        .buttonStyle(.plain)
+
+                        Text("설정")
+                            .font(.system(size: 22, weight: .semibold))
+                            .foregroundStyle(Color.text1)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                            .minimumScaleFactor(0.85)
+
+                        Spacer()
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.top, 30) // 컴팩트에서 윈도우 버튼 고려한 상단 여백
+                    .padding(.bottom, 12)
+                    .safeAreaPadding([.top, .horizontal])
+                } else {
+                    // 💻 iPad/Regular: 기존 헤더 유지
+                    HStack {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("AINO")
+                                .font(.system(size: 28, weight: .semibold))
+                                .foregroundStyle(Color.text1)
+
+                            Text("설정")
+                                .font(.system(size: 22, weight: .medium))
+                                .foregroundStyle(Color.text2)
+                        }
+
+                        Spacer()
+                    }
+                    .padding(.horizontal, 24)
+                    .padding(.top, 12)
+                    .padding(.bottom, 16)
                 }
-                
-                Spacer()
             }
-            .padding(.horizontal, 24)
-            .padding(.top, 12)
-            .padding(.bottom, 16)
             
             // 메인 설정 영역
             ScrollView {

--- a/AINO/Views/HomeView/TrashView.swift
+++ b/AINO/Views/HomeView/TrashView.swift
@@ -5,6 +5,7 @@ import SwiftData
 struct TrashView: View {
     @Environment(\.modelContext) private var context
     @EnvironmentObject private var learningLogStore: LearningLogStore
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     
     @Query private var allNotes: [Note]
     @Query private var allFolders: [Folder]
@@ -86,9 +87,30 @@ struct TrashView: View {
     
     private var header: some View {
         HStack {
+            // 닫기/뒤로가기 버튼: 컴팩트에서만 노출 (사이드바가 없는 환경)
+            if horizontalSizeClass == .compact {
+                Button(action: {
+                    // 홈으로 복귀(되돌아가기) 요청: HomeView에서 스냅샷 복원 처리
+                    NotificationCenter.default.post(name: .homeBackRequested, object: nil)
+                }) {
+                    ZStack {
+                        Circle()
+                            .fill(Color.background2.opacity(0.96))
+                            .frame(width: 44, height: 44)
+                        Image(systemName: "chevron.left")
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundStyle(Color.text2)
+                    }
+                    .contentShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("뒤로가기")
+            }
+
             Text("휴지통")
                 .font(.system(size: 22, weight: .semibold))
                 .foregroundStyle(Color.text1)
+                .padding(.leading, 8)
             Spacer()
             if selectionMode {
                 Button("선택 해제") { selectionMode = false; selectedNotes.removeAll(); selectedFolders.removeAll() }
@@ -114,9 +136,8 @@ struct TrashView: View {
                 .tint(Color.errorColor)
             }
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
         .background(Color.background1)
+        .modifier(CompactHeaderPadding(isCompact: horizontalSizeClass == .compact))
     }
     
     private func sectionHeader(_ title: String) -> some View {
@@ -208,4 +229,28 @@ struct TrashView: View {
         confirmAction = action
         withAnimation(.easeInOut(duration: 0.2)) { showConfirm = true }
     }
+}
+
+private struct CompactHeaderPadding: ViewModifier {
+    let isCompact: Bool
+    func body(content: Content) -> some View {
+        if isCompact {
+            content
+                .padding(.horizontal, 16)
+                .padding(.top, 30)
+                .padding(.bottom, 12)
+                .safeAreaPadding([.top, .horizontal])
+        } else {
+            content
+                .padding(.horizontal, 16)
+                .padding(.top, 6)
+                .padding(.bottom, 8)
+                .safeAreaPadding([.top, .horizontal])
+        }
+    }
+}
+
+extension Notification.Name {
+    static let hideTrash = Notification.Name("HideTrash")
+    static let homeBackRequested = Notification.Name("HomeBackRequested")
 }


### PR DESCRIPTION
[pull_request_template.md](https://github.com/user-attachments/files/22903669/pull_request_template.md)
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #166 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 새로운 컴포넌트 `XxxView` 추가
- API 연동 로직 리팩토링
- 버그 수정: 홈 화면 진입 시 크래시

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="예시 이미지" src="https://...">

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 15, iOS 17.4 환경에서 정상 동작
- [ ] 다크모드 테스트는 이후 이슈로 분리 예정 (#000)

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- `XxxViewModel.swift` 파일의 로직 분리 구조
- `NetworkManager.swift`의 공통 로직 처리 방식
