### PR TITLE
🎨 Design: #200 학습 기록 뷰 자주 선택된 키워드 스크롤뷰에 포함시키기

### DIFF
--- a/AINO/Views/StudyHistoryView/StudyHistoryView.swift
+++ b/AINO/Views/StudyHistoryView/StudyHistoryView.swift
@@ -66,7 +66,7 @@ struct StudyHistoryView: View {
                 .font(.titleText)
                 .foregroundStyle(Color.text1)
 
-            Text("StudyView에서 학습한 노트, 마지막 재생 위치, 선택된 키워드, AI Q&A 기록이 여기에 모입니다.")
+            Text("학습한 노트, 마지막 재생 위치, 선택된 키워드, AI Q&A 기록이 여기에 모입니다.")
                 .font(.captionText)
                 .foregroundStyle(Color.text2)
 
@@ -105,7 +105,7 @@ struct StudyHistoryView: View {
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(Color.text2)
 
-            Text("StudyView에서 영상을 학습하고 키워드를 선택하거나\nAI에게 질문하면 이곳에 자동으로 기록됩니다.")
+            Text("노트에서 영상을 학습하고 키워드를 선택하거나\nAI에게 질문하면 이곳에 자동으로 기록됩니다.")
                 .font(.system(size: 13))
                 .foregroundStyle(Color.text3)
                 .multilineTextAlignment(.center)

--- a/AINO/Views/StudyHistoryView/StudyHistoryView.swift
+++ b/AINO/Views/StudyHistoryView/StudyHistoryView.swift
@@ -51,7 +51,7 @@ struct StudyHistoryView: View {
             }
             .padding(20)
             .background(Color.background1.ignoresSafeArea())
-            .navigationTitle("학습 기록")
+            //.navigationTitle("학습 기록")
         }
     }
 
@@ -362,7 +362,6 @@ struct StudyHistoryView: View {
                         keywordChip(for: stat)
                     }
                 }
-                .padding(.top, 24)
             }
         }
     }
@@ -388,7 +387,7 @@ struct StudyHistoryView: View {
     }
 }
 
-// MARK: - FlexibleView (간단한 플로우 레이아웃)
+// MARK: - Flow layout without GeometryReader so it sizes inside ScrollView
 
 private struct FlexibleView<Data: RandomAccessCollection, Content: View>: View where Data.Element: Hashable {
     let data: Data
@@ -409,40 +408,115 @@ private struct FlexibleView<Data: RandomAccessCollection, Content: View>: View w
     }
 
     var body: some View {
-        GeometryReader { geometry in
-            generateContent(in: geometry)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private func generateContent(in geometry: GeometryProxy) -> some View {
-        var currentX: CGFloat = 0
-        var currentY: CGFloat = 0
-
-        return ZStack(alignment: Alignment(horizontal: alignment, vertical: .top)) {
+        FlowLayout(spacing: spacing, alignment: alignment) {
             ForEach(Array(data), id: \.self) { element in
                 content(element)
-                    .alignmentGuide(.leading) { d in
-                        if currentX + d.width > geometry.size.width {
-                            currentX = 0
-                            currentY -= (d.height + spacing)
-                        }
-                        let result = currentX
-                        currentX += d.width + spacing
-                        return -result
-                    }
-                    .alignmentGuide(.top) { _ in
-                        let result = currentY
-                        return result
-                    }
             }
         }
     }
 }
+
+private struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+    var alignment: HorizontalAlignment = .leading
+
+    init(spacing: CGFloat = 8, alignment: HorizontalAlignment = .leading) {
+        self.spacing = spacing
+        self.alignment = alignment
+    }
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        // Use provided width if available; otherwise assume a reasonably large width.
+        let maxWidth = proposal.width ?? 1000
+        let layout = computeLayout(maxWidth: maxWidth, subviews: subviews)
+        return layout.totalSize
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let maxWidth = bounds.width
+        let layout = computeLayout(maxWidth: maxWidth, subviews: subviews)
+
+        var indexInRow = 0
+        var rowIndex = 0
+
+        for (i, frame) in layout.frames.enumerated() {
+            let xOffset: CGFloat
+            switch alignment {
+            case .center:
+                xOffset = (bounds.width - layout.rowWidths[rowIndex]) / 2
+            case .trailing:
+                xOffset = bounds.width - layout.rowWidths[rowIndex]
+            default:
+                xOffset = 0
+            }
+
+            let origin = CGPoint(x: bounds.minX + frame.origin.x + xOffset,
+                                 y: bounds.minY + frame.origin.y)
+            subviews[i].place(at: origin,
+                              proposal: ProposedViewSize(width: frame.size.width, height: frame.size.height))
+
+            indexInRow += 1
+            if indexInRow >= layout.itemsPerRow[rowIndex] {
+                indexInRow = 0
+                rowIndex += 1
+            }
+        }
+    }
+
+    private func computeLayout(maxWidth: CGFloat, subviews: Subviews)
+    -> (frames: [CGRect], totalSize: CGSize, rowWidths: [CGFloat], itemsPerRow: [Int]) {
+        let finiteWidth = max(0, maxWidth)
+
+        var frames: [CGRect] = []
+        var rowWidths: [CGFloat] = []
+        var itemsPerRow: [Int] = []
+
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var lineHeight: CGFloat = 0
+
+        var currentRowWidth: CGFloat = 0
+        var currentItemsInRow: Int = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(ProposedViewSize(width: finiteWidth, height: nil))
+            let itemWidth = min(size.width, finiteWidth)
+
+            if x > 0 && x + itemWidth > finiteWidth {
+                rowWidths.append(max(0, currentRowWidth - spacing))
+                itemsPerRow.append(currentItemsInRow)
+
+                x = 0
+                y += lineHeight + spacing
+                lineHeight = 0
+                currentRowWidth = 0
+                currentItemsInRow = 0
+            }
+
+            let rect = CGRect(origin: CGPoint(x: x, y: y), size: CGSize(width: itemWidth, height: size.height))
+            frames.append(rect)
+
+            x += itemWidth + spacing
+            currentRowWidth += itemWidth + spacing
+            currentItemsInRow += 1
+            lineHeight = max(lineHeight, size.height)
+        }
+
+        if currentItemsInRow > 0 {
+            rowWidths.append(max(0, currentRowWidth - spacing))
+            itemsPerRow.append(currentItemsInRow)
+        }
+
+        let totalHeight = y + lineHeight
+        let totalWidth = min(finiteWidth, rowWidths.max() ?? finiteWidth)
+
+        return (frames, CGSize(width: totalWidth, height: totalHeight), rowWidths, itemsPerRow)
+    }
+}
+
 #if DEBUG
 #Preview(traits: .landscapeLeft) {
     StudyHistoryView()
         .environmentObject(LearningLogStore.previewStore())
 }
 #endif
-


### PR DESCRIPTION
[pull_request_template.md](https://github.com/user-attachments/files/22903669/pull_request_template.md)
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #200 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 새로운 컴포넌트 `XxxView` 추가
- API 연동 로직 리팩토링
- 버그 수정: 홈 화면 진입 시 크래시

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
 
<img width="1366" height="1024" alt="IMG_2025" src="https://github.com/user-attachments/assets/bd509ac1-cbdb-443a-a3ef-15200a3c7df0" />
<img width="590" height="1278" alt="스크린샷, 2025-11-19 오후 5 08 27" src="https://github.com/user-attachments/assets/badc24bb-5a9a-409b-96b7-9b65fce5aadc" />



---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 15, iOS 17.4 환경에서 정상 동작
- [ ] 다크모드 테스트는 이후 이슈로 분리 예정 (#000)

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- `XxxViewModel.swift` 파일의 로직 분리 구조
- `NetworkManager.swift`의 공통 로직 처리 방식
