### PR TITLE
#236 설정&휴지통 뒤로가기, 선택 시 글자색 변경

### DIFF
--- a/AINO/Views/HomeView/HomeView.swift
+++ b/AINO/Views/HomeView/HomeView.swift
@@ -124,23 +124,29 @@ struct HomeView: View {
             )
             
             NavigationSplitView(columnVisibility: $splitVisibility, preferredCompactColumn: $preferredCompactColumn) {
-                SidebarView(onFolderSelected: { name in
-                    if name == "__ALL__" {
-                        applySelection(folderName: "__ALL__", subtitle: "전체 보기")
-                    } else if let name {
-                        applySelection(folderName: name, subtitle: name)
-                    } else {
-                        applySelection(folderName: nil, subtitle: "최근 열어본 항목")
-                    }
-                }, isHelpPresented: $isHelpPresented, requestDeleteConfirmation: { ids in
-                    folderIDsPendingDelete = ids
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        isFolderDeletePresented = true
-                    }
-                }, selectedFolderName: $selectedFolderName,
-                            folderToRename: $folderToRename,
-                            folderRenameText: $renameText    // ← HomeView의 renameText 재사용
-                        ) // ✅ Pass binding so Sidebar syncs highlight
+                SidebarView(
+                    onFolderSelected: { name in
+                        if name == "__ALL__" {
+                            applySelection(folderName: "__ALL__", subtitle: "전체 보기")
+                        } else if let name {
+                            applySelection(folderName: name, subtitle: name)
+                        } else {
+                            applySelection(folderName: nil, subtitle: "최근 열어본 항목")
+                        }
+                    },
+                    isHelpPresented: $isHelpPresented,
+                    requestDeleteConfirmation: { ids in
+                        folderIDsPendingDelete = ids
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            isFolderDeletePresented = true
+                        }
+                    },
+                    selectedFolderName: $selectedFolderName,
+                    isShowingSettings: $isShowingSettings,
+                    isShowingTrash: $isShowingTrash,
+                    folderToRename: $folderToRename,
+                    folderRenameText: $renameText    // ← HomeView의 renameText 재사용
+                ) // ✅ Pass binding so Sidebar syncs highlight
                 .navigationSplitViewColumnWidth(
                     min: sidebarWidth,
                     ideal: sidebarWidth,
@@ -285,6 +291,7 @@ struct HomeView: View {
                     isShowingTrash = false
                 }
             }
+            /*
             // ✅ 사이드바 숨김 토글 노티 수신 → 실제 표시 상태 토글
             .onReceive(NotificationCenter.default.publisher(for: .toggleSidebar)) { _ in
                 withAnimation(.easeInOut(duration: 0.2)) {
@@ -297,6 +304,26 @@ struct HomeView: View {
 //                    restore(from: snap)
 //                }
 //            }
+
+              
+              */
+            .onReceive(NotificationCenter.default.publisher(for: .toggleSidebar)) { _ in
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                splitVisibility = (splitVisibility == .all) ? .detailOnly : .all
+                            }
+                        }
+                        .onReceive(NotificationCenter.default.publisher(for: .goBack)) { _ in
+                            // 직전 화면 스냅샷이 있으면 복원
+                            if let snap = backStack.popLast() {
+                                restore(from: snap)
+                            } else {
+                                // 스냅샷이 없으면 설정/휴지통 오버레이만 닫기
+                                withAnimation(.easeInOut(duration: 0.2)) {
+                                    if isShowingSettings { isShowingSettings = false }
+                                    if isShowingTrash { isShowingTrash = false }
+                                }
+                            }
+                        }
             .onReceive(NotificationCenter.default.publisher(for: .returnedFromStudyView)) { _ in
                 // 사용자가 StudyView에서 홈으로 돌아왔을 때,
                 // 아직 포스트 온보딩을 보지 않았다면 다시 표시되도록 재무장
@@ -585,10 +612,10 @@ struct HomeView: View {
                         // 심볼: 사이드바 토글 느낌
                         Image(systemName: "sidebar.left")
                             .font(.system(size: 16, weight: .semibold))
+                            .foregroundStyle(Color.text2)
                             .frame(width: metrics.sortButtonSize, height: metrics.sortButtonSize)
                     }
                     .buttonStyle(.plain)
-                    .tint(Color.text2)
                     .glassEffect()
                     .glassEffectUnionCompat(id: "sidebar-toggle", namespace: glassNS)
                     .accessibilityLabel(splitVisibility == .all ? "사이드바 숨기기" : "사이드바 보이기")
@@ -1108,7 +1135,7 @@ extension View {
         }
     }
 }
-
+/*
 // 라우팅용 노티피케이션 추가
 extension Notification.Name {
     static let showSettings = Notification.Name("ShowSettings")
@@ -1116,6 +1143,16 @@ extension Notification.Name {
     static let showTrash = Notification.Name("ShowTrash")
     static let hideTrash = Notification.Name("HideTrash")
     static let returnedFromStudyView = Notification.Name("ReturnedFromStudyView")
+}
+*/
+
+extension Notification.Name {
+    static let showSettings = Notification.Name("ShowSettings")
+    static let hideSettings = Notification.Name("HideSettings")
+    static let showTrash = Notification.Name("ShowTrash")
+    static let hideTrash = Notification.Name("HideTrash")
+    static let returnedFromStudyView = Notification.Name("ReturnedFromStudyView")
+    static let goBack = Notification.Name("GoBack")
 }
 // MARK: - Onboarding (Coach Marks)
 

--- a/AINO/Views/HomeView/HomeView.swift
+++ b/AINO/Views/HomeView/HomeView.swift
@@ -1031,31 +1031,60 @@ extension HomeView {
             default:      return nil
             }
         }
-        
+
+        @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
         var body: some View {
-            ScaledContainer(baseSize: CGSize(width: 1366, height: 1024),
-                            minScale: 0.78,  // 터치 최소 44pt 근사 유지용(원하면 0.75~0.85 사이 조절)
-                            maxScale: 1.0,
-                            alignment: .topLeading) {
-                ZStack {
-                    if showStudyView, let note = selectedNote {
-                        StudyView(note: note) {
-                            showStudyView = false
-                            selectedNote = nil
-                            // 홈으로 복귀 알림 → HomeView에서 포스트 온보딩 재무장
-                            NotificationCenter.default.post(name: .returnedFromStudyView, object: nil)
-                        }
-                    } else {
-                        HomeView(
-                            onNoteSelected: { note in
-                                selectedNote = note
-                                withAnimation { showStudyView = true }
-                            },
-                            onNoteCreated: { note in
-                                selectedNote = note
-                                withAnimation { showStudyView = true }
+            Group {
+                if horizontalSizeClass == .compact {
+                    // 📱 iPhone / compact width: 기존처럼 ScaledContainer 사용
+                    ScaledContainer(baseSize: CGSize(width: 1366, height: 1024),
+                                    minScale: 0.78,  // 터치 최소 44pt 근사 유지용
+                                    maxScale: 1.0,
+                                    alignment: .topLeading) {
+                        ZStack {
+                            if showStudyView, let note = selectedNote {
+                                StudyView(note: note) {
+                                    showStudyView = false
+                                    selectedNote = nil
+                                    // 홈으로 복귀 알림 → HomeView에서 포스트 온보딩 재무장
+                                    NotificationCenter.default.post(name: .returnedFromStudyView, object: nil)
+                                }
+                            } else {
+                                HomeView(
+                                    onNoteSelected: { note in
+                                        selectedNote = note
+                                        withAnimation { showStudyView = true }
+                                    },
+                                    onNoteCreated: { note in
+                                        selectedNote = note
+                                        withAnimation { showStudyView = true }
+                                    }
+                                )
                             }
-                        )
+                        }
+                    }
+                } else {
+                    // 💻 iPad / regular width / Mac: 전체 화면에 NavigationSplitView를 그대로 사용
+                    ZStack {
+                        if showStudyView, let note = selectedNote {
+                            StudyView(note: note) {
+                                showStudyView = false
+                                selectedNote = nil
+                                NotificationCenter.default.post(name: .returnedFromStudyView, object: nil)
+                            }
+                        } else {
+                            HomeView(
+                                onNoteSelected: { note in
+                                    selectedNote = note
+                                    withAnimation { showStudyView = true }
+                                },
+                                onNoteCreated: { note in
+                                    selectedNote = note
+                                    withAnimation { showStudyView = true }
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/AINO/Views/HomeView/HomeView.swift
+++ b/AINO/Views/HomeView/HomeView.swift
@@ -740,6 +740,7 @@ struct HomeView: View {
         .multilineTextAlignment(.center)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .offset(y: -50)
+        .ignoresSafeArea(.keyboard, edges: .bottom)
     }
     
     // Add button visibility: 폴더 내부에서도 노트 추가 가능하도록, 설정 화면에서만 숨김

--- a/AINO/Views/HomeView/ListMode.swift
+++ b/AINO/Views/HomeView/ListMode.swift
@@ -70,6 +70,7 @@ extension HomeView {
         let thumbWidth: CGFloat = 56
         let titleSpacing: CGFloat = 12
         let rowHorizontalPadding: CGFloat = 8
+        let metricColumnWidth: CGFloat = 72
         
         HStack(spacing: 6) {
             Text("제목")
@@ -77,7 +78,6 @@ extension HomeView {
                 .foregroundStyle(Color.text3)
                 .lineLimit(1)
                 .minimumScaleFactor(0.9)
-                .padding(.leading, rowHorizontalPadding + thumbWidth + titleSpacing)
                 .frame(minWidth: 120, maxWidth: .infinity, alignment: .leading)
             
             Text("강의 길이")
@@ -85,21 +85,21 @@ extension HomeView {
                 .foregroundStyle(Color.text3)
                 .lineLimit(1)
                 .minimumScaleFactor(0.9)
-                .frame(width: 60, alignment: .trailing)
+                .frame(width: metricColumnWidth, alignment: .center)
             
             Text("수강률")
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(Color.text3)
                 .lineLimit(1)
                 .minimumScaleFactor(0.9)
-                .frame(width: 60, alignment: .trailing)
+                .frame(width: metricColumnWidth, alignment: .center)
             
             Text("최근 학습 일시")
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(Color.text3)
                 .lineLimit(1)
                 .minimumScaleFactor(0.85)
-                .frame(width: 88, alignment: .trailing)
+                .frame(width: metricColumnWidth, alignment: .center)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
@@ -131,20 +131,20 @@ extension HomeView {
             Text(formatDurationString(note.totalDurationSeconds))
                 .font(.system(size: 14))
                 .foregroundStyle(Color.text2)
-                .frame(width: 60, alignment: .trailing)
+                .frame(width: 72, alignment: .center)
             
             Text(formatProgressPercent(for: note))
                 .font(.system(size: 14))
                 .foregroundStyle(Color.text2)
-                .frame(width: 60, alignment: .trailing)
+                .frame(width: 72, alignment: .center)
             
             Text(NoteFormattingUtils.lastReadText(for: note))
                 .font(.system(size: 14))
                 .foregroundStyle(Color.text2)
-                .frame(width: 88, alignment: .trailing)
+                .frame(width: 72, alignment: .center)
         }
         .padding(.vertical, 10)
-        .padding(.horizontal, 8)
+        .padding(.horizontal, 0)
         .background(
             RoundedRectangle(cornerRadius: 10)
                 .fill(Color.clear)
@@ -213,15 +213,19 @@ extension HomeView {
                     }
                     .frame(minWidth: 120, maxWidth: .infinity, alignment: .leading)
                     
-                    Text("—").frame(width: 60, alignment: .trailing).foregroundStyle(Color.text3)
-                    Text("—").frame(width: 60, alignment: .trailing).foregroundStyle(Color.text3)
+                    Text("—")
+                        .frame(width: 72, alignment: .center)
+                        .foregroundStyle(Color.text3)
+                    Text("—")
+                        .frame(width: 72, alignment: .center)
+                        .foregroundStyle(Color.text3)
                     Text(NoteFormattingUtils.relativeDate(folder.createdAt))
                         .font(.system(size: 14))
                         .foregroundStyle(Color.text2)
-                        .frame(width: 88, alignment: .trailing)
+                        .frame(width: 72, alignment: .center)
                 }
                 .padding(.vertical, 10)
-                .padding(.horizontal, 8)
+                .padding(.horizontal, 0)
                 .background(
                     RoundedRectangle(cornerRadius: 10)
                         .fill(.ultraThinMaterial.opacity(0.3))

--- a/AINO/Views/HomeView/SettingView.swift
+++ b/AINO/Views/HomeView/SettingView.swift
@@ -37,6 +37,7 @@ struct SettingsDetailView: View {
     }
     
     var body: some View {
+        /*
         VStack(spacing: 0) {
             // 헤더 (HomeView와 일관된 스타일)
             HStack(spacing: 12) {
@@ -57,6 +58,41 @@ struct SettingsDetailView: View {
                     .accessibilityLabel("뒤로가기")
                 }
 #endif
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("설정")
+                        .font(.system(size: 22, weight: .bold))
+                        .foregroundStyle(Color.text2)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .minimumScaleFactor(0.85)
+                }
+                Spacer()
+            }
+            .padding()
+            .safeAreaPadding([.top, .horizontal])
+            
+            Divider().background(Color.borderColor)
+         */
+        VStack(spacing: 0) {
+            // 헤더 (HomeView와 일관된 스타일)
+            HStack(spacing: 12) {
+                // 🔙 좌측 상단 뒤로가기 버튼 (항상 표시)
+                Button {
+                    performDismiss()
+                } label: {
+                    ZStack {
+                        Circle()
+                            .fill(Color.background2.opacity(0.96))
+                            .frame(width: 32, height: 32)
+                        Image(systemName: "chevron.left")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundStyle(Color.text2)
+                    }
+                    .contentShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("뒤로가기")
+                
                 VStack(alignment: .leading, spacing: 4) {
                     Text("설정")
                         .font(.system(size: 22, weight: .bold))
@@ -201,7 +237,7 @@ struct SettingsDetailView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color(.systemBackground))
         // ✅ 드래그 오프셋 적용
-        .offset(x: dragOffset)
+        //.offset(x: dragOffset)
         // ✅ 드래그 중일 때 살짝 어둡게
         .overlay(
             Color.black.opacity(isDragging ? 0.1 : 0)
@@ -263,6 +299,7 @@ struct SettingsDetailView: View {
             }
     }
     
+    /*
     private func performDismiss() {
         withAnimation(.easeOut(duration: 0.25)) {
             dragOffset = UIScreen.main.bounds.width
@@ -271,6 +308,16 @@ struct SettingsDetailView: View {
         // 뒤로가기 로직
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
             NotificationCenter.default.post(name: .hideSettings, object: nil)
+        }
+    }*/
+    private func performDismiss() {
+        withAnimation(.easeOut(duration: 0.25)) {
+            dragOffset = UIScreen.main.bounds.width
+        }
+        
+        // 뒤로가기 로직: 직전 화면으로 복귀 요청
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            NotificationCenter.default.post(name: .goBack, object: nil)
         }
     }
 }

--- a/AINO/Views/HomeView/SidebarView.swift
+++ b/AINO/Views/HomeView/SidebarView.swift
@@ -155,7 +155,8 @@ private extension SidebarView {
             }
             .padding(.horizontal, 20)
             // 고정 50 → 안전영역을 고려한 top 패딩
-            .safeAreaPadding(.top, 12)
+            // 고정 50 → 안전영역을 고려한 top 패딩 (조금 더 여유 있게)
+            .safeAreaPadding(.top, 16)
             .padding(.bottom, 16)
             .contentShape(Rectangle())
 
@@ -475,8 +476,8 @@ private extension SidebarView {
             }
             .buttonStyle(.plain)
         }
-        // 고정 30 → 안전영역 포함 하단 패딩
-        .safeAreaPadding(.bottom, 16)
+        // 고정 30 → 안전영역 포함 하단 패딩 (조금 줄임)
+        //.safeAreaPadding(.bottom, 5)
         .ignoresSafeArea(.keyboard, edges: .bottom)
         .padding(.horizontal, 12)
         .contentShape(Rectangle())

--- a/AINO/Views/HomeView/SidebarView.swift
+++ b/AINO/Views/HomeView/SidebarView.swift
@@ -16,21 +16,29 @@ struct SidebarView: View {
     let requestDeleteConfirmation: ((Set<PersistentIdentifier>) -> Void)?
     // ✅ 홈에서 현재 선택된 카테고리(전체/최근/특정 폴더 이름)를 바인딩으로 전달받아 동기화
     @Binding var selectedFolderName: String?
+    
+    // 🔵 추가: 설정/휴지통 오버레이 표시 여부와 연동해서 하단 버튼 색 바꾸기
+        @Binding var isShowingSettings: Bool
+        @Binding var isShowingTrash: Bool
 
     init(
         onFolderSelected: ((String?) -> Void)? = nil,
         isHelpPresented: Binding<Bool> = .constant(false),
         requestDeleteConfirmation: ((Set<PersistentIdentifier>) -> Void)? = nil,
         selectedFolderName: Binding<String?> = .constant(nil),
+        isShowingSettings: Binding<Bool> = .constant(false),
+        isShowingTrash: Binding<Bool> = .constant(false),
         folderToRename: Binding<Folder?> = .constant(nil),
-            folderRenameText: Binding<String> = .constant("")
+        folderRenameText: Binding<String> = .constant("")
     ) {
         self.onFolderSelected = onFolderSelected
         self._isHelpPresented = isHelpPresented
         self.requestDeleteConfirmation = requestDeleteConfirmation
         self._selectedFolderName = selectedFolderName
+        self._isShowingSettings = isShowingSettings
+        self._isShowingTrash = isShowingTrash
         self._folderToRename = folderToRename
-            self._folderRenameText = folderRenameText
+        self._folderRenameText = folderRenameText
     }
     
     @StateObject private var viewModel = SidebarViewModel()
@@ -234,6 +242,9 @@ private extension SidebarView {
             NotificationCenter.default.post(name: .hideSettings, object: nil)
         } label: {
             let isSelected = (viewModel.selection == .all)
+                && !isHelpPresented
+                && !isShowingSettings
+                && !isShowingTrash
             HStack(spacing: 12) {
                 Image(systemName: "square.grid.2x2.fill")
                     .foregroundStyle(isSelected ? Color.secondColor : Color.text2)
@@ -327,6 +338,10 @@ private extension SidebarView {
             onFolderSelected?(folder.name)
         } label: {
             let isSelected: Bool = {
+                // 하단 메뉴(도움말/설정/휴지통)가 활성화된 동안에는 폴더 하이라이트를 끈다
+                if isHelpPresented || isShowingSettings || isShowingTrash {
+                    return false
+                }
                 if case .folder(let id) = viewModel.selection {
                     return id == folder.persistentModelID
                 }
@@ -425,6 +440,9 @@ private extension SidebarView {
                 onFolderSelected?(nil)
             } label: {
                 let isSelected = (viewModel.selection == .recent)
+                    && !isHelpPresented
+                    && !isShowingSettings
+                    && !isShowingTrash
                 HStack/*(spacing: 12)*/ {
                     Image(systemName: "clock.fill")
                         .foregroundStyle(isSelected ? Color.secondColor : Color.text2)
@@ -443,10 +461,16 @@ private extension SidebarView {
     
     var bottomBar: some View {
         VStack(spacing: 0) {
+            // ✅ 도움말 버튼
             Button { viewModel.helpTapped() } label: {
+                let isSelected = isHelpPresented
                 HStack(spacing: 12) {
-                    Image(systemName: "questionmark.circle.fill").foregroundStyle(Color.text2).font(.system(size: 20))
-                    Text("도움말").foregroundStyle(Color.text2).font(.buttonText)
+                    Image(systemName: "questionmark.circle.fill")
+                        .foregroundStyle(isSelected ? Color.secondColor : Color.text2)
+                        .font(.system(size: 20))
+                    Text("도움말")
+                        .foregroundStyle(isSelected ? Color.secondColor : Color.text2)
+                        .font(.buttonText)
                     Spacer()
                 }
                 .padding(.horizontal, 20)
@@ -454,10 +478,16 @@ private extension SidebarView {
             }
             .buttonStyle(.plain)
 
+            // ✅ 설정 버튼
             Button { NotificationCenter.default.post(name: .showSettings, object: nil) } label: {
+                let isSelected = isShowingSettings
                 HStack(spacing: 12) {
-                    Image(systemName: "gearshape.fill").foregroundStyle(Color.text2).font(.system(size: 20))
-                    Text("설정").foregroundStyle(Color.text2).font(.buttonText)
+                    Image(systemName: "gearshape.fill")
+                        .foregroundStyle(isSelected ? Color.secondColor : Color.text2)
+                        .font(.system(size: 20))
+                    Text("설정")
+                        .foregroundStyle(isSelected ? Color.secondColor : Color.text2)
+                        .font(.buttonText)
                     Spacer()
                 }
                 .padding(.horizontal, 20)
@@ -465,10 +495,16 @@ private extension SidebarView {
             }
             .buttonStyle(.plain)
 
+            // ✅ 휴지통 버튼
             Button { NotificationCenter.default.post(name: .showTrash, object: nil) } label: {
+                let isSelected = isShowingTrash
                 HStack(spacing: 12) {
-                    Image(systemName: "trash").foregroundStyle(Color.errorColor).font(.system(size: 20))
-                    Text("휴지통").foregroundStyle(Color.errorColor).font(.buttonText)
+                    Image(systemName: "trash")
+                        .foregroundStyle(isSelected ? Color.errorColor : Color.errorColor.opacity(0.75))
+                        .font(.system(size: 20))
+                    Text("휴지통")
+                        .foregroundStyle(isSelected ? Color.errorColor : Color.errorColor.opacity(0.75))
+                        .font(.buttonText)
                     Spacer()
                 }
                 .padding(.horizontal, 20)
@@ -476,8 +512,6 @@ private extension SidebarView {
             }
             .buttonStyle(.plain)
         }
-        // 고정 30 → 안전영역 포함 하단 패딩 (조금 줄임)
-        //.safeAreaPadding(.bottom, 5)
         .ignoresSafeArea(.keyboard, edges: .bottom)
         .padding(.horizontal, 12)
         .contentShape(Rectangle())

--- a/AINO/Views/HomeView/SidebarView.swift
+++ b/AINO/Views/HomeView/SidebarView.swift
@@ -148,10 +148,10 @@ private extension SidebarView {
                 Spacer()
 
                 // ✅ 숨김 버튼을 정렬 버튼 왼쪽에, 5pt 간격으로 항상 표시
-                hideSidebarButton
+                sortMenu
                     .padding(.trailing, 5)
 
-                sortMenu
+                hideSidebarButton
             }
             .padding(.horizontal, 20)
             // 고정 50 → 안전영역을 고려한 top 패딩

--- a/AINO/Views/HomeView/TrashView.swift
+++ b/AINO/Views/HomeView/TrashView.swift
@@ -129,24 +129,22 @@ struct TrashView: View {
         VStack(spacing: 0) {
             // 홈뷰와 일치하는 헤더 바
             HStack(spacing: 12) {
-                // .compact 환경에서 뒤로가기 버튼 제공
-#if os(iOS)
-                if UIDevice.current.userInterfaceIdiom == .phone {
-                    Button {
-                        NotificationCenter.default.post(name: .hideTrash, object: nil)
-                    } label: {
+                // 🔙 좌측 상단 뒤로가기 버튼 (설정 화면과 동일한 스타일)
+                Button {
+                    NotificationCenter.default.post(name: .goBack, object: nil)
+                } label: {
+                    ZStack {
+                        Circle()
+                            .fill(Color.background2.opacity(0.96))
+                            .frame(width: 32, height: 32)
                         Image(systemName: "chevron.left")
                             .font(.system(size: 16, weight: .semibold))
-                            .padding(8)
-                            .frame(minWidth: 44, minHeight: 44)
-                            .contentShape(Circle())
-                            .clipShape(Circle())
-                            .tint(Color.text2)
+                            .foregroundStyle(Color.text2)
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("뒤로가기")
+                    .contentShape(Circle())
                 }
-#endif
+                .buttonStyle(.plain)
+                .accessibilityLabel("뒤로가기")
                 
                 VStack(alignment: .leading, spacing: 4) {
                     Text("휴지통")


### PR DESCRIPTION
[pull_request_template.md](https://github.com/user-attachments/files/22903669/pull_request_template.md)
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 설정&휴지통 뒤로가기
-  설정&휴지통 선택 시 글자색 변경


---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="예시 이미지" src="https://...">

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 15, iOS 17.4 환경에서 정상 동작
- [ ] 다크모드 테스트는 이후 이슈로 분리 예정 (#000)

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- `XxxViewModel.swift` 파일의 로직 분리 구조
- `NetworkManager.swift`의 공통 로직 처리 방식
